### PR TITLE
add a procedure that cleans lucene directory for rebuilding when Keny…

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/EmrActivator.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/EmrActivator.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.kenyaemr;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.log4j.Level;
@@ -17,6 +18,10 @@ import org.openmrs.api.context.Context;
 import org.openmrs.module.ModuleActivator;
 import org.openmrs.module.kenyacore.CoreContext;
 import org.openmrs.module.reporting.report.service.ReportService;
+import org.openmrs.util.OpenmrsUtil;
+
+import java.io.File;
+import java.io.IOException;
 
 /**
  * This class contains the logic that is run every time this module is either started or stopped.
@@ -35,7 +40,25 @@ public class EmrActivator implements ModuleActivator {
 	 * @see ModuleActivator#willRefreshContext()
 	 */
 	public void willRefreshContext() {
+
 		log.info("KenyaEMR context refreshing...");
+		//TODO: explore the best method to rebuild lucene files after disruptive power outage
+		// remove content of lucene
+		File luceneDir = OpenmrsUtil.getDirectoryInApplicationDataDirectory("lucene");
+		String fullDirPath = luceneDir.getPath() + File.separator + "indexes";
+
+		File indexesDir = new File(fullDirPath);
+		log.info("Remove all lucene files for fresh rebuild...");
+		try {
+			FileUtils.cleanDirectory(indexesDir);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		log.info("Successfully removed all lucene files for fresh rebuild...");
+
+
+
 	}
 
 	/**


### PR DESCRIPTION
…aEMR context is refreshing. This is a temp solution to corrupted lucene indexes mostly after power outages