### PR TITLE
Added global property to determine facility for autogeneration of UPNs,when  generateUPN =true, default is false

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/form/velocity/EmrVelocityFunctions.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/form/velocity/EmrVelocityFunctions.java
@@ -224,6 +224,21 @@ public class EmrVelocityFunctions {
 		}
 		return "Unknown Location";
 	}
+
+	/**
+	 * This facility types will have their UPN Generation enabled
+	 * @param conceptIdentifier the concept identifier
+	 *
+	 */
+	public String getFacilityToGenerateUPN() {
+		AdministrationService administrationService = org.openmrs.api.context.Context.getAdministrationService();
+		GlobalProperty globalProperty = administrationService.getGlobalPropertyObject("kenyaemr.generateUPN");
+		if (globalProperty.getValue() != null) {
+			return globalProperty.getPropertyValue();
+		}
+		return "true";
+	}
+
 	public List<Obs> allObs(String conceptIdentifier) {
 		if (session.getPatient() == null)
 			return new ArrayList<Obs>();

--- a/api/src/main/java/org/openmrs/module/kenyaemr/form/velocity/EmrVelocityFunctions.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/form/velocity/EmrVelocityFunctions.java
@@ -230,7 +230,7 @@ public class EmrVelocityFunctions {
 	 * @param conceptIdentifier the concept identifier
 	 *
 	 */
-	public String getFacilityToGenerateUPN() {
+	public String generateUPN() {
 		AdministrationService administrationService = org.openmrs.api.context.Context.getAdministrationService();
 		GlobalProperty globalProperty = administrationService.getGlobalPropertyObject("kenyaemr.generateUPN");
 		if (globalProperty.getValue() != null) {

--- a/api/src/main/java/org/openmrs/module/kenyaemr/metadata/CommonMetadata.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/metadata/CommonMetadata.java
@@ -150,6 +150,8 @@ public class CommonMetadata extends AbstractMetadataBundle {
 
 		install(globalProperty("order.drugDosingUnitsConceptUuid", "Drug dosing units concept", "162384AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
 
+		install(globalProperty("kenyaemr.generateUPN", "Defines facility to enable UPN Autogeneration", "false"));
+
 		install(patientIdentifierType("Old Identification Number", "Identifier given out prior to OpenMRS",
 				null, null, null,
 				LocationBehavior.NOT_USED, false, _PatientIdentifierType.OLD_ID));

--- a/omod/src/main/webapp/resources/htmlforms/hiv/hivEnrollment.html
+++ b/omod/src/main/webapp/resources/htmlforms/hiv/hivEnrollment.html
@@ -27,6 +27,8 @@
         var ctxPath = typeof openmrsContextPath === 'string' ? openmrsContextPath : OPENMRS_CONTEXT_PATH;
         var GREENCARD_VELOCITY = "<lookup expression="kenyaemr.GreenCardVelocityCalculation()" />";
         var ENROLLED_IN_HIV = GREENCARD_VELOCITY.split(",")[12].split(":")[1];
+        var GENERATE_UPN = <lookup expression="kenyaemr.getFacilityToGenerateUPN()" />;
+
         //On Ready
         jq(function() {
             var confirmed_positive = "<lookup expression="fn.latestObs(159427).getValueCoded()"/>"; // this is the HTS final result
@@ -66,7 +68,7 @@
             });
             //onEntryPointChange();
             //defaults
-            jq('#generate-hiv-id').hide();
+            jq('#generate-hiv-id').show();
             //Gender based validations  pregnancy, breastfeeding bmi and muac
             if (pgender == 'M') {
                 jq('#pregnant :input').prop('disabled', true);
@@ -281,6 +283,8 @@
             if (entryPointStatus == NEW_CLIENT) {
                 var facility_confirmed = "<lookup expression="fn.latestObs(162724).getValueText()"/>";
                 jq('#hiv-id :input').prop('disabled', false);
+                jq('#gen-hiv-id :input').prop('disabled', false);
+                jq('#generate-hiv-id').show();
                 jq('#transfer-details').hide();
                 jq('#patient-history').show();
                 jq('#art-history').show();
@@ -298,8 +302,6 @@
                 jq('#ldl :input').prop('disabled', true);
                 jq('#ldl-date :input').prop('disabled', true);
                 jq('#patient-regimen select').prop('disabled', true);
-
-                //jq('#generate-hiv-id').show(); Deactivate generate upn
                 jq('#transit-patient').hide();
                 //Gender based validations  pregnancy and breastfeeding
                 if (pgender == 'M') {
@@ -323,6 +325,7 @@
             if (entryPointStatus== TRANSFER_IN) {
                 jq('#transfer-details :input').prop('disabled', false);
                 jq('#hiv-id :input').prop('disabled', false);
+                jq('#gen-hiv-id :input').prop('disabled', false);
                 jq('#generate-hiv-id').hide();
                 jq('#transfer-details').show();
                 jq('#patient-history').show();
@@ -359,39 +362,38 @@
             }
             if (entryPointStatus== TRANSIT) {
                 jq('#hiv-id :input').prop('disabled', false);
+                jq('#gen-hiv-id :input').prop('disabled', false);
+                jq('#generate-hiv-id').hide();
                 jq('#transit-patient').show();
                 jq('#transfer-details').hide();
                 jq('#patient-history').hide();
                 jq('#art-history').hide();
                 jq('#baseline-fieldset').hide();
                 jq('#treatment-supporter-fieldset').hide();
-                jq('#hiv-id :input').prop('disabled', false);
-                jq('#generate-hiv-id').hide();
                 clearHiddenSections([transferDetails, dateConfirmedPositive, facilityConfirmedPositive, whoAdult, whoChild, artStatus, pmtctChecked, pepChecked, prepChecked, haartChecked,baselineFieldset]);
             }
             if (entryPointStatus == RE_ENROLL) {
                 jq('#hiv-id :input').prop('disabled', true);
+                jq('#gen-hiv-id :input').prop('disabled', true);
+                jq('#generate-hiv-id').hide();
                 jq('#transit-patient').hide();
                 jq('#transfer-details').hide();
                 jq('#patient-history').hide();
                 jq('#art-history').hide();
                 jq('#baseline-fieldset').hide();
                 jq('#treatment-supporter-fieldset').hide();
-                jq('#hiv-id :input').prop('disabled', false);
-                jq('#generate-hiv-id').hide();
                 clearHiddenSections([transferDetails, whoAdult, whoChild, artStatus, pmtctChecked, pepChecked, prepChecked, haartChecked, baselineFieldset]);
             }
             if (entryPointStatus == false) {
                 jq('#hiv-id :input').prop('disabled', false);
+                jq('#gen-hiv-id :input').prop('disabled', false);
+                jq('#generate-hiv-id').hide();
                 jq('#transit-patient').hide();
                 jq('#transfer-details').hide();
                 jq('#patient-history').hide();
                 jq('#art-history').hide();
                 jq('#baseline-fieldset').hide();
                 jq('#treatment-supporter-fieldset').hide();
-                jq('#hiv-id :input').prop('disabled', false);
-                jq('#generate-hiv-id').hide();
-                //jq("#entry-point :input").prop("checked", false);
                 clearHiddenSections([transferDetails, whoAdult, whoChild, artStatus, pmtctChecked, pepChecked, prepChecked, haartChecked, baselineFieldset]);
             }
         }
@@ -421,7 +423,7 @@
                 okLabel: 'Continue',
                 okCallback: function() {
                     jq.getJSON('/' + ctxPath + '/kenyaemr/emrUtils/nextHivUniquePatientNumber.action', function(data) {
-                        jq('#hiv-id input[type=text]').val(data.value);
+                        jq('#gen-hiv-id input[type=text]').val(data.value);
                         jq('#generate-hiv-id').hide();
                     });
                 }
@@ -560,6 +562,7 @@
 					</obsgroup></td>
 					</td>
 				</tr>
+				 <excludeIf velocityTest="$kenyaemr.getFacilityToGenerateUPN()==true">
 				<tr>
 					<td>Unique Patient Number (UPN)</td>
 					<td> &#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;
@@ -567,6 +570,19 @@
 						<span id="upnError" class="error"></span>
 					</td>
 				</tr>
+				 </excludeIf>
+				 <excludeIf velocityTest="$kenyaemr.getFacilityToGenerateUPN()==false">
+				<tr>
+					<td>Unique Patient Number (UPN)</td>
+					<td> &#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;
+						<span id="gen-hiv-id"><patient id="upn" field="identifier" identifierTypeId="05ee9cf4-7242-4a17-b4d4-00f707265c8a" /></span>
+						<span id="upnError" class="error"></span>
+						 <excludeIf velocityTest="$kenyaemr.hasHivUniquePatientNumber()">
+							<input type="button" id="generate-hiv-id" value="Generate"/>
+						 </excludeIf>
+					</td>
+				</tr>
+				 </excludeIf>
 			</table>
 			<table id="transit-patient" style="display: inline-block">
 				<tr>

--- a/omod/src/main/webapp/resources/htmlforms/hiv/hivEnrollment.html
+++ b/omod/src/main/webapp/resources/htmlforms/hiv/hivEnrollment.html
@@ -27,7 +27,6 @@
         var ctxPath = typeof openmrsContextPath === 'string' ? openmrsContextPath : OPENMRS_CONTEXT_PATH;
         var GREENCARD_VELOCITY = "<lookup expression="kenyaemr.GreenCardVelocityCalculation()" />";
         var ENROLLED_IN_HIV = GREENCARD_VELOCITY.split(",")[12].split(":")[1];
-        var GENERATE_UPN = <lookup expression="kenyaemr.getFacilityToGenerateUPN()" />;
 
         //On Ready
         jq(function() {
@@ -283,7 +282,6 @@
             if (entryPointStatus == NEW_CLIENT) {
                 var facility_confirmed = "<lookup expression="fn.latestObs(162724).getValueText()"/>";
                 jq('#hiv-id :input').prop('disabled', false);
-                jq('#gen-hiv-id :input').prop('disabled', false);
                 jq('#generate-hiv-id').show();
                 jq('#transfer-details').hide();
                 jq('#patient-history').show();
@@ -325,7 +323,6 @@
             if (entryPointStatus== TRANSFER_IN) {
                 jq('#transfer-details :input').prop('disabled', false);
                 jq('#hiv-id :input').prop('disabled', false);
-                jq('#gen-hiv-id :input').prop('disabled', false);
                 jq('#generate-hiv-id').hide();
                 jq('#transfer-details').show();
                 jq('#patient-history').show();
@@ -362,7 +359,6 @@
             }
             if (entryPointStatus== TRANSIT) {
                 jq('#hiv-id :input').prop('disabled', false);
-                jq('#gen-hiv-id :input').prop('disabled', false);
                 jq('#generate-hiv-id').hide();
                 jq('#transit-patient').show();
                 jq('#transfer-details').hide();
@@ -374,7 +370,6 @@
             }
             if (entryPointStatus == RE_ENROLL) {
                 jq('#hiv-id :input').prop('disabled', true);
-                jq('#gen-hiv-id :input').prop('disabled', true);
                 jq('#generate-hiv-id').hide();
                 jq('#transit-patient').hide();
                 jq('#transfer-details').hide();
@@ -386,7 +381,6 @@
             }
             if (entryPointStatus == false) {
                 jq('#hiv-id :input').prop('disabled', false);
-                jq('#gen-hiv-id :input').prop('disabled', false);
                 jq('#generate-hiv-id').hide();
                 jq('#transit-patient').hide();
                 jq('#transfer-details').hide();
@@ -423,7 +417,7 @@
                 okLabel: 'Continue',
                 okCallback: function() {
                     jq.getJSON('/' + ctxPath + '/kenyaemr/emrUtils/nextHivUniquePatientNumber.action', function(data) {
-                        jq('#gen-hiv-id input[type=text]').val(data.value);
+                        jq('#hiv-id input[type=text]').val(data.value);
                         jq('#generate-hiv-id').hide();
                     });
                 }
@@ -562,27 +556,18 @@
 					</obsgroup></td>
 					</td>
 				</tr>
-				 <excludeIf velocityTest="$kenyaemr.getFacilityToGenerateUPN()==true">
 				<tr>
 					<td>Unique Patient Number (UPN)</td>
 					<td> &#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;
 						<span id="hiv-id"><patient id="upn" field="identifier" identifierTypeId="05ee9cf4-7242-4a17-b4d4-00f707265c8a" /></span>
 						<span id="upnError" class="error"></span>
-					</td>
-				</tr>
-				 </excludeIf>
-				 <excludeIf velocityTest="$kenyaemr.getFacilityToGenerateUPN()==false">
-				<tr>
-					<td>Unique Patient Number (UPN)</td>
-					<td> &#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;
-						<span id="gen-hiv-id"><patient id="upn" field="identifier" identifierTypeId="05ee9cf4-7242-4a17-b4d4-00f707265c8a" /></span>
-						<span id="upnError" class="error"></span>
 						 <excludeIf velocityTest="$kenyaemr.hasHivUniquePatientNumber()">
-							<input type="button" id="generate-hiv-id" value="Generate"/>
+							 <excludeIf velocityTest="$kenyaemr.generateUPN()==false">
+							      <input type="button" id="generate-hiv-id" value="Generate"/>
+							 </excludeIf>
 						 </excludeIf>
 					</td>
 				</tr>
-				 </excludeIf>
 			</table>
 			<table id="transit-patient" style="display: inline-block">
 				<tr>


### PR DESCRIPTION
Added global property to determine facility for autogeneration of UPNs,when  generateUPN =true, default is false
This feature is only available for new clients as transits, TI and reenrollments are deemed to already have UPNS.
Set global property generateUPN to true to access this feature