### PR TITLE
Revert "Fix for java-lang-illegalstateexception-two-resources-with-the-same-name-v1-activelisttype-must-not-have-the-same-order error when accessing drug orders page"

### DIFF
--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -27,6 +27,11 @@
 	<dependencies>
 
 		<dependency>
+			<groupId>org.openmrs.module</groupId>
+			<artifactId>webservices.rest-omod-1.8</artifactId>
+			<version>${webservicesRestVersion}</version>
+		</dependency>
+		<dependency>
 			<groupId>${project.parent.groupId}</groupId>
 			<artifactId>${project.parent.artifactId}-api</artifactId>
 			<version>${project.parent.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <reportingVersion>0.9.8.1</reportingVersion>
         <serializationxstreamVersion>0.2.7</serializationxstreamVersion>
         <uiframeworkVersion>3.8</uiframeworkVersion>
-        <webservicesRestVersion>2.11</webservicesRestVersion>
+        <webservicesRestVersion>2.1</webservicesRestVersion>
         <facilityReportingVersion>1.0.0</facilityReportingVersion>
         <apacheHttpClientVersion>4.5.10</apacheHttpClientVersion>
         <!--


### PR DESCRIPTION
Reverts palladiumkenya/openmrs-module-kenyaemr#731