### PR TITLE
Fetch all visits haven't ended or been closed and close them on startup and using a scheduler

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/task/AutoCloseActiveVisitsTask.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/task/AutoCloseActiveVisitsTask.java
@@ -1,0 +1,61 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.kenyaemr.task;
+
+import org.openmrs.Patient;
+import org.openmrs.Visit;
+import org.openmrs.api.context.Context;
+import org.openmrs.scheduler.tasks.AbstractTask;
+import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * A scheduled task that automatically closes all unvoided active visits
+ * Set date_stopped to 11 23:59:59 of the date_started
+ */
+public class AutoCloseActiveVisitsTask extends AbstractTask {
+	
+	private static final Logger log = LoggerFactory.getLogger(AutoCloseActiveVisitsTask.class);
+	
+	/**
+	 * @see AbstractTask#execute()
+	 */
+	@Override
+	public void execute() {
+		if (!isExecuting) {
+			if (log.isDebugEnabled()) {
+				log.debug("Starting Auto Close Visits Task...");
+			}
+
+			startExecuting();
+			List<Patient> allPatients = Context.getPatientService().getAllPatients();
+
+			// Fetch all visits haven't ended or been closed and close them
+			List<Visit> visits = Context.getVisitService().getVisits(null, allPatients, null, null, null, new Date(), null, null, null, true, false);
+			if (visits.size() > 0) {
+				for (Visit visit : visits) {
+					try {
+
+					visit.setStopDatetime(OpenmrsUtil.getLastMomentOfDay(visit.getStartDatetime()));
+
+					} catch (Exception e) {
+						log.error("Error while auto closing visits:", e);
+					} finally {
+						stopExecuting();
+					}
+				}
+			}
+		}
+	}
+}

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -171,4 +171,44 @@
 		</sql>
 	</changeSet>
 
+	<!--Removing scheduled Openmrs based Autoclose visits task-->
+	<changeSet id="${project.parent.artifactId}-20220209-1120" author="pwangoo">
+		<preConditions onFail="MARK_RAN">
+			<sqlCheck expectedResult="1">
+				SELECT COUNT(*) FROM scheduler_task_config
+				WHERE schedulable_class = 'org.openmrs.scheduler.tasks.AutoCloseVisitsTask'
+				And name = 'Auto Close Visits Task'
+			</sqlCheck>
+		</preConditions>
+		<comment>Deleting Openmrs AutoCloseVisitsTask Task from 'schedule_task_config' table</comment>
+		<delete tableName="scheduler_task_config">
+			<where>schedulable_class='org.openmrs.scheduler.tasks.AutoCloseVisitsTask'</where>
+		</delete>
+	</changeSet>
+
+	<!--Adding scheduled Openmrs based Autoclose visits task-->
+	<changeSet id="${project.parent.artifactId}-20220210-1120" author="pwangoo">
+		<preConditions onFail="MARK_RAN">
+			<sqlCheck expectedResult="0">
+				SELECT COUNT(*) FROM scheduler_task_config
+				WHERE schedulable_class = 'org.openmrs.module.kenyaemr.task.AutoCloseActiveVisitsTask'
+				And name = 'Autoclose active visits Task'
+			</sqlCheck>
+		</preConditions>
+		<comment>Inserting Autoclose active visits Task into 'schedule_task_config' table</comment>
+		<insert tableName="scheduler_task_config">
+			<column name="name" value="Autoclose active visits Task" />
+			<column name="description" value="Stops all active outpatient kenyaemr visits" />
+			<column name="schedulable_class" value="org.openmrs.module.kenyaemr.task.AutoCloseActiveVisitsTask" />
+			<column name="start_time_pattern" value="MM/dd/yyyy HH:mm:ss" />
+			<column name="start_time" valueDate="2022-02-09T23:59:59" />
+			<column name="repeat_interval" value="7200" />
+			<column name="date_created" valueDate="CURRENT_TIMESTAMP" />
+			<column name="created_by" value="1" />
+			<column name="start_on_startup" value="0" />
+			<column name="started" value="0" />
+			<column name="uuid" value="c2e923d1-723d-4e33-a055-67c959b4490c" />
+		</insert>
+	</changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Fetch all visits haven't ended or been closed and close them on startup and using a scheduler
1. Autocloses on startup by default
2. Autocloses when the scheduler is set
![Autoclose_scheduler](https://user-images.githubusercontent.com/1901372/154016165-04bb319f-95db-4dbd-bd5b-c6c4f143e7d2.PNG)

