### PR TITLE
Removed prefix copies/ml from lastViralLoadResult calculation and appended this to cohorDialog

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/hiv/art/LastViralLoadResultCalculation.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/hiv/art/LastViralLoadResultCalculation.java
@@ -45,7 +45,7 @@ public class LastViralLoadResultCalculation extends AbstractPatientCalculation {
             Obs numericVLObs = EmrCalculationUtils.obsResultForPatient(numericViralLoadValues, ptId);
             Obs ldlVLObs = EmrCalculationUtils.obsResultForPatient(ldlViralLoadValues, ptId);
             if(numericVLObs != null && ldlVLObs == null){
-                object = SimpleObject.create("lastVl", numericVLObs.getValueNumeric()+" copies/ml", "lastVlDate", numericVLObs.getObsDatetime());
+                object = SimpleObject.create("lastVl", numericVLObs.getValueNumeric(), "lastVlDate", numericVLObs.getObsDatetime());
             }
            if(numericVLObs == null && ldlVLObs != null){
                object = SimpleObject.create("lastVl", "LDL", "lastVlDate", ldlVLObs.getObsDatetime());
@@ -61,7 +61,7 @@ public class LastViralLoadResultCalculation extends AbstractPatientCalculation {
                 }
 
                 if(lastViralLoadPicked.getConcept().equals(Dictionary.getConcept(Dictionary.HIV_VIRAL_LOAD))) {
-                    object = SimpleObject.create("lastVl", lastViralLoadPicked.getValueNumeric()+" copies/ml", "lastVlDate", numericVLObs.getObsDatetime());
+                    object = SimpleObject.create("lastVl", lastViralLoadPicked.getValueNumeric(), "lastVlDate", numericVLObs.getObsDatetime());
                 }
                 else {
                     object = SimpleObject.create("lastVl", "LDL", "lastVlDate", ldlVLObs.getObsDatetime());

--- a/omod/src/main/webapp/pages/dialog/cohortDialog.gsp
+++ b/omod/src/main/webapp/pages/dialog/cohortDialog.gsp
@@ -20,7 +20,7 @@
 				<th>Unique Patient Number</th>
                 <th>HIV Enrollment Date</th>
                 <th>ART Start Date</th>
-				<th>Last VL</th>
+				<th>Last VL(copies/ml)</th>
 				<th>Last VL Date</th>
 			</tr>
 		</thead>


### PR DESCRIPTION
Removed prefix copies/ml from lastViralLoadResult calculation and appended this to cohorDialog
This is meant to facilitate reuse of lastViralLoadResult  calculation without having to strip the copies/ml part