### PR TITLE
Bug fix on checking null for latestBloodPressure instead of checking latestRespiratoryRate on setting respiratory rate

### DIFF
--- a/omod/src/main/java/org/openmrs/module/kenyaemr/fragment/controller/SummariesFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemr/fragment/controller/SummariesFragmentController.java
@@ -254,7 +254,7 @@ public class SummariesFragmentController {
 
         CalculationResultMap respiratoryRate = Calculations.lastObs(Dictionary.getConcept(Dictionary.RESPIRATORY_RATE), Arrays.asList(patient.getId()), context);
         Obs latestRespiratoryRate = EmrCalculationUtils.obsResultForPatient(respiratoryRate, patient.getPatientId());
-        if(latestBloodPressure != null){
+        if(latestRespiratoryRate != null){
             patientSummary.setRespiratoryRate(latestRespiratoryRate.getValueNumeric().toString());
         }
         else {


### PR DESCRIPTION
Bug fix on checking null for latestBloodPressure instead of checking latestRespiratoryRate on setting respiratory rate