### PR TITLE
TB screening and clinical encounter form should be dropped for HIV

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/hiv/HIVEnrollment.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/hiv/HIVEnrollment.java
@@ -1,0 +1,51 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.kenyaemr.calculation.library.hiv;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.Program;
+import org.openmrs.calculation.patient.PatientCalculationContext;
+import org.openmrs.calculation.result.CalculationResultMap;
+import org.openmrs.module.kenyacore.calculation.AbstractPatientCalculation;
+import org.openmrs.module.kenyacore.calculation.BooleanResult;
+import org.openmrs.module.kenyacore.calculation.Filters;
+import org.openmrs.module.kenyaemr.metadata.HivMetadata;
+import org.openmrs.module.metadatadeploy.MetadataUtils;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Checks if a patient is enrolled in HIV program
+ */
+public class HIVEnrollment extends AbstractPatientCalculation {
+
+    protected static final Log log = LogFactory.getLog(HIVEnrollment.class);
+
+    @Override
+    public CalculationResultMap evaluate(Collection<Integer> cohort, Map<String, Object> parameterValues, PatientCalculationContext context) {
+        Program hivProgram = MetadataUtils.existing(Program.class, HivMetadata._Program.HIV);
+        Set<Integer> alive = Filters.alive(cohort, context);
+        Set<Integer> inHivProgram = Filters.inProgram(hivProgram, alive, context);
+        CalculationResultMap ret = new CalculationResultMap();
+        boolean inProgram = false;
+        for (Integer ptId : cohort) {
+            if (!inHivProgram.contains(ptId)) {
+                inProgram = true;
+            }
+            ret.put(ptId, new BooleanResult(inProgram, this));
+        }
+        return ret;
+    }
+
+}
+

--- a/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/hiv/HIVEnrollment.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/hiv/HIVEnrollment.java
@@ -1,15 +1,4 @@
-/**
- * This Source Code Form is subject to the terms of the Mozilla Public License,
- * v. 2.0. If a copy of the MPL was not distributed with this file, You can
- * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
- * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
- *
- * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
- * graphic logo is a trademark of OpenMRS Inc.
- */
-package org.openmrs.module.kenyaemr.calculation.library.hiv;
-
-import org.apache.commons.logging.Log;
+package org.openmrs.module.kenyaemr.calculation.library.hiv;import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.Program;
 import org.openmrs.calculation.patient.PatientCalculationContext;
@@ -19,18 +8,15 @@ import org.openmrs.module.kenyacore.calculation.BooleanResult;
 import org.openmrs.module.kenyacore.calculation.Filters;
 import org.openmrs.module.kenyaemr.metadata.HivMetadata;
 import org.openmrs.module.metadatadeploy.MetadataUtils;
-
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
 /**
- * Checks if a patient is enrolled in HIV program
+ * Calculations to Checks if a patient is enrolled in HIV program
  */
 public class HIVEnrollment extends AbstractPatientCalculation {
-
     protected static final Log log = LogFactory.getLog(HIVEnrollment.class);
-
     @Override
     public CalculationResultMap evaluate(Collection<Integer> cohort, Map<String, Object> parameterValues, PatientCalculationContext context) {
         Program hivProgram = MetadataUtils.existing(Program.class, HivMetadata._Program.HIV);

--- a/api/src/main/resources/content/kenyaemr.common.xml
+++ b/api/src/main/resources/content/kenyaemr.common.xml
@@ -34,7 +34,7 @@
 				<ref bean="kenyaemr.common.form.htsinitialtest"/>
 				<ref bean="kenyaemr.common.form.htsconfirmatorytest"/>
 				<ref bean="kenyaemr.common.form.htsLinkage"/>
-			    <ref bean="kenyaemr.common.form.cervicalCancerScreening"/>
+				<ref bean="kenyaemr.common.form.cervicalCancerScreening"/>
 				<ref bean="kenyaemr.common.form.cervicalCancerAssessment"/>
 				<ref bean="kenyaemr.hiv.form.genderBasedViolenceScreening"/>
 				<ref bean="kenyaemr.common.form.hivSelfTesting"/>
@@ -62,7 +62,7 @@
 				<ref bean="kenyaemr.common.report.activePatientsLinelist" />
 				<ref bean="kenyaemr.common.report.allPatientsMissingIdentifiers" />
 				<ref bean="kenyaemr.common.report.rdqaReport" />
-<!--				<ref bean="kenyaemr.common.report.clients.died" />-->
+				<!--				<ref bean="kenyaemr.common.report.clients.died" />-->
 				<ref bean="kenyaemr.common.report.clients.transferred.in" />
 				<ref bean="kenyaemr.common.report.clients.transferred.out" />
 				<ref bean="kenyaemr.hiv.report.htsPositiveCLientsNotLinkedToCare"/>
@@ -198,6 +198,7 @@
 				<ref bean="kenyaemr.app.chart" />
 			</set>
 		</property>
+		<property name="showIfCalculation" value="org.openmrs.module.kenyaemr.calculation.library.hiv.HIVEnrollment" />
 		<property name="icon" value="kenyaui:forms/generic.png" />
 		<property name="htmlform" value="kenyaemr:clinicalEncounter.html" />
 		<property name="order" value="200015" />
@@ -257,6 +258,7 @@
 				<ref bean="kenyaemr.app.chart" />
 			</set>
 		</property>
+		<property name="showIfCalculation" value="org.openmrs.module.kenyaemr.calculation.library.hiv.HIVEnrollment" />
 		<property name="icon" value="kenyaui:forms/generic.png" />
 		<property name="htmlform" value="kenyaemr:tb/tbScreening.html" />
 		<property name="order" value="200014" />
@@ -585,7 +587,7 @@
 	<bean id="kenyaemr.common.report.allPatientsMissingIdentifiers" class="org.openmrs.module.kenyacore.report.HybridReportDescriptor">
 		<property name="targetUuid" value="c7fbb62a-c165-11ec-9d64-0242ac120002" />
 		<property name="name" value="All Patients Missing National Unique Patient Identifier" />
-	    <property name="description" value="List of clients who do not have national unique patient identifier listed" />
+		<property name="description" value="List of clients who do not have national unique patient identifier listed" />
 		<property name="apps">
 			<set>
 				<ref bean="kenyaemr.app.reports" />
@@ -593,19 +595,19 @@
 		</property>
 	</bean>
 
-    <!-- =========================== RDQA Reports =============================-->
-    <bean id="kenyaemr.common.report.rdqaReport" class="org.openmrs.module.kenyacore.report.HybridReportDescriptor">
-        <property name="targetUuid" value="ed1cfbf2-64c6-11e4-86ed-10c37b209d8a" />
-        <property name="name" value="RDQA Report" />
-        <property name="description" value="Report for Routine Data Quality Analysis" />
-        <property name="apps">
-            <set>
-                <ref bean="kenyaemr.app.reports" />
-            </set>
+	<!-- =========================== RDQA Reports =============================-->
+	<bean id="kenyaemr.common.report.rdqaReport" class="org.openmrs.module.kenyacore.report.HybridReportDescriptor">
+		<property name="targetUuid" value="ed1cfbf2-64c6-11e4-86ed-10c37b209d8a" />
+		<property name="name" value="RDQA Report" />
+		<property name="description" value="Report for Routine Data Quality Analysis" />
+		<property name="apps">
+			<set>
+				<ref bean="kenyaemr.app.reports" />
+			</set>
 		</property>
-        <property name="template" value="kenyaemr:rdqa/rdqaTemplate.xls" />
-        <property name="repeatingSection" value="sheet:1,row:11,dataset:allPatients | sheet:2,row:11,dataset:activePatients " />
-    </bean>
+		<property name="template" value="kenyaemr:rdqa/rdqaTemplate.xls" />
+		<property name="repeatingSection" value="sheet:1,row:11,dataset:allPatients | sheet:2,row:11,dataset:activePatients " />
+	</bean>
 
 	<bean id="kenyaemr.common.report.currentInCareNotStartedOnART" class="org.openmrs.module.kenyacore.report.HybridReportDescriptor">
 		<property name="targetUuid" value="0e325e0e-e60e-40be-b83b-e4e30d0ffdd0" />
@@ -634,13 +636,13 @@
 
 	</bean>
 
-<!--	<bean id="kenyaemr.common.report.clients.died" class="org.openmrs.module.kenyacore.report.HybridReportDescriptor">-->
-<!--		<property name="targetUuid" value="d4c6805e-7ecf-11e5-8b43-10c37b209c79" />-->
-<!--		<property name="name" value="Clients died" />-->
-<!--		<property name="description" value="Patients who have died" />-->
-<!--		<property name="apps"><set><ref bean="kenyaemr.app.reports" /></set></property>-->
+	<!--	<bean id="kenyaemr.common.report.clients.died" class="org.openmrs.module.kenyacore.report.HybridReportDescriptor">-->
+	<!--		<property name="targetUuid" value="d4c6805e-7ecf-11e5-8b43-10c37b209c79" />-->
+	<!--		<property name="name" value="Clients died" />-->
+	<!--		<property name="description" value="Patients who have died" />-->
+	<!--		<property name="apps"><set><ref bean="kenyaemr.app.reports" /></set></property>-->
 
-<!--	</bean>-->
+	<!--	</bean>-->
 
 	<!-- MER indicators-->
 	<bean id="kenyaemr.common.report.mer-indicators" class="org.openmrs.module.kenyacore.report.IndicatorReportDescriptor">


### PR DESCRIPTION
TB screening and clinical encounter form should be dropped for HIV+ clients to avoid duplication of efforts




