### PR TITLE
TB screening and clinical encounter form should be dropped for HIV+ 

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/hiv/HIVEnrollment.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/hiv/HIVEnrollment.java
@@ -1,0 +1,51 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.kenyaemr.calculation.library.hiv;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.Program;
+import org.openmrs.calculation.patient.PatientCalculationContext;
+import org.openmrs.calculation.result.CalculationResultMap;
+import org.openmrs.module.kenyacore.calculation.AbstractPatientCalculation;
+import org.openmrs.module.kenyacore.calculation.BooleanResult;
+import org.openmrs.module.kenyacore.calculation.Filters;
+import org.openmrs.module.kenyaemr.metadata.HivMetadata;
+import org.openmrs.module.metadatadeploy.MetadataUtils;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Checks if a patient is enrolled in HIV program
+ */
+public class HIVEnrollment extends AbstractPatientCalculation {
+
+    protected static final Log log = LogFactory.getLog(HIVEnrollment.class);
+
+    @Override
+    public CalculationResultMap evaluate(Collection<Integer> cohort, Map<String, Object> parameterValues, PatientCalculationContext context) {
+        Program hivProgram = MetadataUtils.existing(Program.class, HivMetadata._Program.HIV);
+        Set<Integer> alive = Filters.alive(cohort, context);
+        Set<Integer> inHivProgram = Filters.inProgram(hivProgram, alive, context);
+        CalculationResultMap ret = new CalculationResultMap();
+        boolean inProgram = false;
+        for (Integer ptId : cohort) {
+            if (!inHivProgram.contains(ptId)) {
+                inProgram = true;
+            }
+            ret.put(ptId, new BooleanResult(inProgram, this));
+        }
+        return ret;
+    }
+
+}
+

--- a/api/src/main/resources/content/kenyaemr.common.xml
+++ b/api/src/main/resources/content/kenyaemr.common.xml
@@ -198,6 +198,7 @@
 				<ref bean="kenyaemr.app.chart" />
 			</set>
 		</property>
+		<property name="showIfCalculation" value="org.openmrs.module.kenyaemr.calculation.library.hiv.HIVEnrollment" />
 		<property name="icon" value="kenyaui:forms/generic.png" />
 		<property name="htmlform" value="kenyaemr:clinicalEncounter.html" />
 		<property name="order" value="200015" />
@@ -257,6 +258,7 @@
 				<ref bean="kenyaemr.app.chart" />
 			</set>
 		</property>
+		<property name="showIfCalculation" value="org.openmrs.module.kenyaemr.calculation.library.hiv.HIVEnrollment" />
 		<property name="icon" value="kenyaui:forms/generic.png" />
 		<property name="htmlform" value="kenyaemr:tb/tbScreening.html" />
 		<property name="order" value="200014" />


### PR DESCRIPTION
TB screening and clinical encounter form should be dropped for HIV+ clients to avoid duplication of efforts