### PR TITLE
TB screening and clinical encounter form should be dropped for clients

### DIFF
--- a/api/src/main/resources/content/kenyaemr.common.xml
+++ b/api/src/main/resources/content/kenyaemr.common.xml
@@ -29,6 +29,7 @@
 				<ref bean="kenyaemr.common.form.triage" />
 				<ref bean="kenyaemr.common.form.clinicalEncounter" />
 				<ref bean="kenyaemr.common.form.labResults" />
+				<ref bean="kenyaemr.common.form.tbScreening" />
 				<!--<ref bean="kenyaemr.common.form.otherMedications" />-->
 				<ref bean="kenyaemr.common.form.progressNote" />
 				<ref bean="kenyaemr.common.form.htsinitialtest"/>

--- a/api/src/main/resources/content/kenyaemr.hiv.xml
+++ b/api/src/main/resources/content/kenyaemr.hiv.xml
@@ -33,6 +33,7 @@
 				<ref bean="kenyaemr.hiv.form.alcoholAndDrugAbuseScreening" />
 				<ref bean="kenyaemr.hiv.form.enhancedAdherenceScreening" />
 				<!--<ref bean="kenyaemr.hiv.form.clinicalEncounterAddendum" />-->
+<!--				<ref bean="kenyaemr.common.form.tbScreening" />-->
 				<ref bean="kenyaemr.hiv.form.artFastTrackForm"/>
 				<ref bean="kenyaemr.hiv.form.cccDefaulterTracing"/>
 			</set>

--- a/api/src/main/resources/content/kenyaemr.hiv.xml
+++ b/api/src/main/resources/content/kenyaemr.hiv.xml
@@ -238,6 +238,7 @@
 				<ref bean="kenyaemr.app.chart" />
 			</set>
 		</property>
+		<property name="showIfCalculation" value="org.openmrs.module.kenyaemr.calculation.library.hiv.HIVEnrollment" />
 		<property name="icon" value="kenyaui:forms/generic.png" />
 		<property name="htmlform" value="kenyaemr:tb/tbScreening.html" />
 		<property name="order" value="200014" />

--- a/api/src/main/resources/content/kenyaemr.hiv.xml
+++ b/api/src/main/resources/content/kenyaemr.hiv.xml
@@ -33,7 +33,6 @@
 				<ref bean="kenyaemr.hiv.form.alcoholAndDrugAbuseScreening" />
 				<ref bean="kenyaemr.hiv.form.enhancedAdherenceScreening" />
 				<!--<ref bean="kenyaemr.hiv.form.clinicalEncounterAddendum" />-->
-				<ref bean="kenyaemr.common.form.tbScreening" />
 				<ref bean="kenyaemr.hiv.form.artFastTrackForm"/>
 				<ref bean="kenyaemr.hiv.form.cccDefaulterTracing"/>
 			</set>
@@ -225,23 +224,6 @@
 		<property name="icon" value="kenyaui:forms/moh257.png" />
 		<property name="htmlform" value="kenyaemr:hiv/moh257VisitSummary.html" />
 		<property name="order" value="201030" />
-	</bean>
-
-	<!-- ====================== adding TB Screening forms =================== -->
-
-	<!-- Clinical Encounter - TB Screening -->
-	<bean id="kenyaemr.common.form.tbScreening" class="org.openmrs.module.kenyacore.form.FormDescriptor">
-		<property name="targetUuid" value="59ed8e62-7f1f-40ae-a2e3-eabe350277ce" />
-		<property name="apps">
-			<set>
-				<ref bean="kenyaemr.app.clinician" />
-				<ref bean="kenyaemr.app.chart" />
-			</set>
-		</property>
-		<property name="showIfCalculation" value="org.openmrs.module.kenyaemr.calculation.library.hiv.HIVEnrollment" />
-		<property name="icon" value="kenyaui:forms/generic.png" />
-		<property name="htmlform" value="kenyaemr:tb/tbScreening.html" />
-		<property name="order" value="200014" />
 	</bean>
 
 	<!-- Clinical Encounter - Gene Xpert Form -->


### PR DESCRIPTION
TB screening and clinical encounter form should be dropped for clients enrolled in HIV program to avoid duplication of efforts