### PR TITLE
Allowing prisoner facilities allow national Id verification for civilians in prison facilities. National ID will take precedence than prisoner ID in consultation with BA

### DIFF
--- a/omod/src/main/webapp/fragments/patient/editPatient.gsp
+++ b/omod/src/main/webapp/fragments/patient/editPatient.gsp
@@ -832,7 +832,7 @@ ${ui.includeFragment("kenyaui", "widget/dialogForm", [
 
         if("${isPrison}"=="true"){
             jQuery('#prisoner-service-no').show();
-            jQuery('#national-identification-no').hide();
+            jQuery('#national-identification-no').show();
         }
         else {
             jQuery('#prisoner-service-no').hide();


### PR DESCRIPTION
Allowing prisoner facilities allow national Id verification for civilians in prison facilities. National ID will take precedence than prisoner ID in consultation with BA