### PR TITLE
Add a field to record mother;s ART prophilaxis

### DIFF
--- a/omod/src/main/webapp/resources/htmlforms/mchms/mchmsDelivery.html
+++ b/omod/src/main/webapp/resources/htmlforms/mchms/mchmsDelivery.html
@@ -1453,6 +1453,26 @@
                                 </td>
                             </tr>
                             <tr>
+                                <td>Mother issued with ART prophylaxis from ANC</td>
+                                <td>
+                                    <obs class ="art-prophylaxis-from-anc"
+                                         conceptId="1149AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                                         answerConceptIds="1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1175AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                                         answerLabels="Yes,No,N/A"
+                                         style="radio" id="art-prophylaxis-from-anc" />
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Mother issued with ART prophylaxis at maternity?</td>
+                                <td>
+                                    <obs class ="art-prophylaxis-at-maternity"
+                                         conceptId="166665AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                                         answerConceptIds="1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1175AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                                         answerLabels="Yes,No,N/A"
+                                         style="radio" id="art-prophylaxis-at-maternity" />
+                                </td>
+                            </tr>
+                            <tr>
                                 <td>NVP for the baby dispensed?</td>
                                 <td>
                                     <obs class ="nvp-prescribed"

--- a/omod/src/main/webapp/resources/htmlforms/mchms/mchmsDelivery.html
+++ b/omod/src/main/webapp/resources/htmlforms/mchms/mchmsDelivery.html
@@ -401,6 +401,7 @@
                 jq('#initiated-arv-prophylaxis').hide();
                 jq('#initiated-arv-prophylaxis-twins').hide();
                 jq('#initiated-arv-prophylaxis-triplets').hide();
+                clearHiddenSections(jq('#started-haart-anc'));
             }
         }
 
@@ -1443,26 +1444,6 @@
                                 </td>
                             </tr>
                             <tr>
-                                <td>AZT for the baby dispensed?</td>
-                                <td>
-                                    <obs class ="azt-prescribed"
-                                         conceptId="1282AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                                         answerConceptIds="160123AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1175AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                                         answerLabels="Yes,No,N/A"
-                                         style="radio" id="azt-dispensed" />
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Mother issued with ART prophylaxis from ANC</td>
-                                <td>
-                                    <obs class ="art-prophylaxis-from-anc"
-                                         conceptId="1149AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                                         answerConceptIds="1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1175AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                                         answerLabels="Yes,No,N/A"
-                                         style="radio" id="art-prophylaxis-from-anc" />
-                                </td>
-                            </tr>
-                            <tr>
                                 <td>Mother issued with ART prophylaxis at maternity?</td>
                                 <td>
                                     <obs class ="art-prophylaxis-at-maternity"
@@ -1472,14 +1453,15 @@
                                          style="radio" id="art-prophylaxis-at-maternity" />
                                 </td>
                             </tr>
+
                             <tr>
-                                <td>NVP for the baby dispensed?</td>
+                                <td>Mother issued with ART prophylaxis from ANC</td>
                                 <td>
-                                    <obs class ="nvp-prescribed"
-                                         conceptId="1282AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                                         answerConceptIds="80586AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1175AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                                    <obs class ="art-prophylaxis-from-anc"
+                                         conceptId="1149AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                                         answerConceptIds="1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1175AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
                                          answerLabels="Yes,No,N/A"
-                                         style="radio" id="nvp-dispensed" />
+                                         style="radio" id="art-prophylaxis-from-anc" />
                                 </td>
                             </tr>
                             <tr>
@@ -1501,6 +1483,26 @@
                                             answerConceptIds="1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1067AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
                                             answerLabels="Yes,No,N/A"
                                             style="radio"/>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>AZT for the baby dispensed?</td>
+                                <td>
+                                    <obs class ="azt-prescribed"
+                                         conceptId="1282AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                                         answerConceptIds="160123AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1175AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                                         answerLabels="Yes,No,N/A"
+                                         style="radio" id="azt-dispensed" />
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>NVP for the baby dispensed?</td>
+                                <td>
+                                    <obs class ="nvp-prescribed"
+                                         conceptId="1282AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                                         answerConceptIds="80586AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1175AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                                         answerLabels="Yes,No,N/A"
+                                         style="radio" id="nvp-dispensed" />
                                 </td>
                             </tr>
                         </table>


### PR DESCRIPTION
![art_prophylaxis](https://user-images.githubusercontent.com/8075969/216331097-88add367-40d7-409b-a7f6-1d73b8a9048f.jpg)

Add a filed in the form to record if the mother was given ART prophylaxis in the ANC or during the delivery visit. The two variables to be included are:

- Mother issued with ART prophylaxis from ANC
- Mother issued with ART prophylaxis at maternity.
Acceptance criteria.
- Allow the user to record either ‘Y or N for the option of ‘Mother issued with ART prophylaxis at the maternity’ if mother tested positive at maternity else N/A if the mother was a known positive.
- Allow the user to record either ‘Y ' or ‘N’ for the option of ‘Mother issued with ART prophylaxis from ANC’ if the mother was a known positive at the time of getting to delivery else N/A if the mother’s HIV status was Negative or Unknown before the time of the delivery.