### PR TITLE
Enhance the defaulter tracing form by adding more features.

### DIFF
--- a/omod/src/main/webapp/resources/htmlforms/hiv/cccDefaulterTracing.html
+++ b/omod/src/main/webapp/resources/htmlforms/hiv/cccDefaulterTracing.html
@@ -24,8 +24,25 @@
             jq('#final-outcome :input[type=radio]').change(onFinalOutcomeChange);
             jq('#contact-status :input[type=radio]').change(onContactStatusChange);
             jq("#missed-appointment-reasons select").change(onOtherReasonsSelected);
+            jq('#true-status :input[type=radio]').change(trueStatus);
             jq('#booking-date :input').prop('disabled', true);
             jq('#tbl-other-reasons').hide();
+            jq('#other-specify-no-contact').hide();
+            jq("#reasonForContact").hide();
+            jq("#reasonForNotContact").hide();
+            jq("#discontinuation-msg").hide();
+
+
+            jq("#idNotContactReason select").change(function() {
+                if ((getValue('idNotContactReason.value')) == 5622) {
+                    jq('#other-specify-no-contact').show();
+                } else {
+                    jq('#other-specify-no-contact').hide();
+                    clearHiddenSections(jq('#other-specify-no-contact'));
+				}
+
+            });
+
 
             beforeSubmit.push(function () {
                 var reasonForMissedAppointment = jq('#missed-appointment-reasons option:selected').val();
@@ -50,17 +67,32 @@
                     clearHiddenSections([final_status,final_status_other]);
                     }
         }
+        function trueStatus(){
+            var val = getValue('true-status.value');
+            if(val == 160432 || val == 1693 ) {
+                jq('#discontinuation-msg').show();
+            }else{
+                jq('#discontinuation-msg').hide();
+                clearHiddenSections(jq("#discontinuation-msg"));
+            }
+        }
+
 
         function onContactStatusChange(){
             var val = getValue('contact-status.value');
             if(val == 1267) {
                 jq('#booking-date :input').prop('disabled', false);
                 jq('#missed-appointment').show();
+                jq("#reasonForNotContact").hide();
+                clearHiddenSections(jq("#reasonForNotContact"));
             }else{
                 jq('#booking-date :input').prop('disabled', true);
                 jq('#missed-appointment').hide();
+                 jq("#reasonForNotContact").show();
+                clearHiddenSections(jq("#missed-appointment"));
             }
         }
+
 
         //Specify other Reasons for missing appointments
         function onOtherReasonsSelected() {
@@ -166,15 +198,15 @@
                     <td>
                         <obs conceptId="164093AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" id="missed_appointment-date" allowFutureDates="true" required="true"/>
                         &#160;&#160;&#160;&#160;&#160;&#160;
-                     </td>
+                    </td>
                 </tr>
                 <tr>
                 <tr></tr><tr></tr>
-                    <td>Type of tracing</td>
-                    <td>
-                        <obs id="tracing_type" conceptId="a55f9516-ddb6-47ec-b10d-cb99d1d0bd41" answerConceptIds="1650AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,eb113c76-aef8-4890-a611-fe22ba003123,161642AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                             answerLabels="Client Called,Physical Tracing,Treatment Supporter" required="true" style="radio"/>
-                    </td>
+                <td>Type of tracing</td>
+                <td>
+                    <obs id="tracing_type" conceptId="a55f9516-ddb6-47ec-b10d-cb99d1d0bd41" answerConceptIds="1650AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,eb113c76-aef8-4890-a611-fe22ba003123,161642AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                         answerLabels="Client Called,Physical Tracing,Treatment Supporter" required="true" style="radio"/>
+                </td>
                 </tr>
             </table>
         </fieldset>
@@ -192,7 +224,18 @@
                         Date promised to come :
                         <obs conceptId="163526AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" id="booking-date" allowFutureDates="true"/>
                     </td>
+
+
                 </tr>
+                <tr id="reasonForNotContact">
+                    <td >
+                        Reason not Contact:
+                        <obs conceptId="166541AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" answerConceptIds="163723AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,166538AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,165075,160034AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,1302AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" answerLabels="Tracking ongoing,No locator information,Inaccurate locator information,Died,Calls not going through,Other" id="idNotContactReason" /></td>
+                </tr>
+                <td id="other-specify-no-contact">Specify :
+                    <obs conceptId="160632AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" />
+                    &#160;&#160;&#160;
+                </td>
             </table>
         </fieldset>
         <fieldset id="missed-appointment">
@@ -271,10 +314,10 @@
                              answerLabels="Dead,Receiving ART from another clinic/Transferred,Still in care at CCC,Lost to follow up,Stopped treatment,Other - Please explain" answerSeparator="&lt;br /&gt;" style="radio"/>
                         <obs id="true-status-other" conceptId="160632AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" />
                     </td>
+                    <td id="discontinuation-msg">Complete the HIV Discontinuation form</td>
                 </tr>
             </table>
         </fieldset>
-
         <fieldset>
             <legend>Provider Comments</legend>
 


### PR DESCRIPTION
Enhance the defaulter tracing form by adding more features.

If the Final Outcome/True Status is either ‘Dead' or ‘Receiving ART from another clinic/Transferred’ add a message 'Complete the HIV Discontinuation form’ for the user to action.

If not contacted add a drop down showing Reason not contacted. The options should be Tracking ongoing, No locator information, Inaccurate locator information, Died, Calls not going through and Other. If other add a text area to specify.
![cccdefaultTra](https://user-images.githubusercontent.com/8075969/235124393-4cda3e21-24e6-4485-9c29-e4007319c622.jpg)
