### PR TITLE
Add Complete the HIV Discontinuation from banner

### DIFF
--- a/omod/src/main/webapp/resources/htmlforms/hiv/cccDefaulterTracing.html
+++ b/omod/src/main/webapp/resources/htmlforms/hiv/cccDefaulterTracing.html
@@ -314,9 +314,10 @@
                              answerLabels="Dead,Receiving ART from another clinic/Transferred,Still in care at CCC,Lost to follow up,Stopped treatment,Other - Please explain" answerSeparator="&lt;br /&gt;" style="radio"/>
                         <obs id="true-status-other" conceptId="160632AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" />
                     </td>
-                    <td id="discontinuation-msg">Complete the HIV Discontinuation form</td>
                 </tr>
             </table>
+            <div id="discontinuation-msg" style="width: 100%; float: left; overflow: auto; text-align: left; padding: 5px"><span class="ke-flagtag">Complete the HIV Discontinuation form</span>
+            </div>
         </fieldset>
         <fieldset>
             <legend>Provider Comments</legend>


### PR DESCRIPTION
Enhance the defaulter tracing form by adding more features.
If the Final Outcome/True Status is either ‘Dead' or ‘Receiving ART from another clinic/Transferred’ add a bunner for 'Complete the HIV Discontinuation form’ for the user to action.
![banner](https://user-images.githubusercontent.com/8075969/236612227-73c4510d-6479-4393-946e-8d1d80d1a36a.jpg)

