### PR TITLE
Updated HIV positive status criteria to use Initial test in Datim. In…

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/reporting/library/ETLReports/MOH731Greencard/ETLMoh731GreenCardCohortLibrary.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/reporting/library/ETLReports/MOH731Greencard/ETLMoh731GreenCardCohortLibrary.java
@@ -2460,8 +2460,7 @@ public class ETLMoh731GreenCardCohortLibrary {
                 "         inner join kenyaemr_etl.etl_mch_antenatal_visit v on e.patient_id = v.patient_id\n" +
                 "where date(v.visit_date) between date(:startDate) and date(:endDate)\n" +
                 "    and v.anc_visit_number = 1\n" +
-                "    and v.partner_hiv_status in (703, 664)\n" +
-                "   or date(e.visit_date) between date(:startDate) and date(:endDate) and e.partner_hiv_status in (703, 664);";
+                "    and coalesce(v.partner_hiv_status,e.partner_hiv_status) in (703, 664);";
         cd.setName("knownHIVStatusAt1stContact");
         cd.setQuery(sqlQuery);
         cd.addParameter(new Parameter("startDate", "Start Date", Date.class));

--- a/api/src/main/java/org/openmrs/module/kenyaemr/reporting/library/ETLReports/RevisedDatim/DatimCohortLibrary.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/reporting/library/ETLReports/RevisedDatim/DatimCohortLibrary.java
@@ -2512,7 +2512,7 @@ public class DatimCohortLibrary {
      * Patients who received initial HIV test with Positive result within a reporting period
      */
     public CohortDefinition positiveHIVTestResult() {
-        String sqlQuery = "select hts.patient_id from kenyaemr_etl.etl_hts_test hts where hts.test_type =2 and hts.final_test_result ='Positive' and hts.patient_given_result ='Yes'" +
+        String sqlQuery = "select hts.patient_id from kenyaemr_etl.etl_hts_test hts where hts.test_type =1 and hts.final_test_result ='Positive' and hts.patient_given_result ='Yes'" +
                 " and hts.voided =0 and hts.visit_date between date(:startDate) and date(:endDate) group by hts.patient_id;";
         SqlCohortDefinition cd = new SqlCohortDefinition();
         cd.setName("HTS_TST_Positive");


### PR DESCRIPTION
… MOH731 HV02-29 (Known partner HIV status), dropped those who are new/with one ANC visit if the ANC visit number is not documented as 1