### PR TITLE
Add RHZE as a regimen in the TB Regimen history for the children.

### DIFF
--- a/api/src/main/resources/regimens.xml
+++ b/api/src/main/resources/regimens.xml
@@ -528,6 +528,12 @@
                 <component drugCode="R60" units="tab" frequency="OD" />
                 <!--<component drugCode="H60" units="tab" frequency="OD" />-->
             </regimen>
+            <regimen name="RHZE" conceptRef="1675AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" orderSetRef="d647932b-5825-46e5-b0d7-8ddcff5f3303">
+                <component drugCode="R150" dose="1" units="tab" frequency="OD" />
+                <component drugCode="H75" dose="1" units="tab" frequency="OD" />
+                <component drugCode="Z400" dose="1" units="tab" frequency="OD" />
+                <component drugCode="E275" dose="1" units="tab" frequency="OD" />
+            </regimen>
             <regimen name="RHZ" conceptRef="768AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" orderSetRef="07add7bb-77b0-492a-820e-d0a6ebab6e36">
                 <component drugCode="R150" dose="1" units="tab" frequency="OD" />
                 <!--<component drugCode="H50" dose="1" units="tab" frequency="OD" />

--- a/omod/src/main/webapp/resources/htmlforms/hiv/treatmentPreparation.html
+++ b/omod/src/main/webapp/resources/htmlforms/hiv/treatmentPreparation.html
@@ -227,6 +227,56 @@
                     </obsgroup>
                 </table>
             </fieldset>
+
+            <fieldset id="medical-criteria-tab">
+                <legend>
+                    Medical Criteria (applies to patients)
+                </legend>
+                <table class="simple-table" id="medical-criteria-screening-questions">
+                    <obsgroup groupingConceptId="160525AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA">
+                        <tr>
+
+                            <td>1. Newly diagnosed with TB:<b>defer ART until patient tolerates anti-TB medication;<br></br>
+                                initiate ART as soon as possible preferably within 2 weeks; for TB meningitis<br></br>
+                                delay ART for 4 to 8 weeks); monitor closely for IRIS
+                            </b>
+
+                            </td>
+                            <td>
+
+                            </td>
+                            <td>
+
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>2. Newly diagnosed cryptococcal meningitis (CM), or symptoms consistent with CM <br></br>
+                                (progressive headache, fever, malaise, neck pain, confusion): <b>defer ART until <br></br>
+                                    completed 5 weeks of CM treatment, or until ruling out CM as the cause of <br></br>
+                                    symptoms;monitor closely for IRIS</b>
+
+                            </td>
+                            <td>
+
+                            </td>
+                            <td>
+
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <b>
+                                    *If the response to any of the psychosocial criteria or support systems criteria is "No":develop a <br></br>
+                                    strategy to address the issue as quickly as possible and consider assigning a case manager. ART<br></br>
+                                    may be initiated with adequate adherence support while the criteria is being addressed, on a <br></br>
+                                    case-by-case basis
+                                </b>
+                            </td>
+
+                        </tr>
+                    </obsgroup>
+                </table>
+            </fieldset>
         </fieldset>
     </div>
     <div class="ke-form-footer">


### PR DESCRIPTION
Add RHZE as a regimen in the TB Regimen history for the children. Currently the regimen is lacking. The regimen should be added in the intensive phase (child) list.