### PR TITLE
Add RHZE as a regimen in the TB Regimen history for the children.

### DIFF
--- a/api/src/main/resources/regimens.xml
+++ b/api/src/main/resources/regimens.xml
@@ -528,6 +528,12 @@
                 <component drugCode="R60" units="tab" frequency="OD" />
                 <!--<component drugCode="H60" units="tab" frequency="OD" />-->
             </regimen>
+            <regimen name="RHZE" conceptRef="1675AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" orderSetRef="d647932b-5825-46e5-b0d7-8ddcff5f3303">
+                <component drugCode="R150" dose="1" units="tab" frequency="OD" />
+                <component drugCode="H75" dose="1" units="tab" frequency="OD" />
+                <component drugCode="Z400" dose="1" units="tab" frequency="OD" />
+                <component drugCode="E275" dose="1" units="tab" frequency="OD" />
+            </regimen>
             <regimen name="RHZ" conceptRef="768AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" orderSetRef="07add7bb-77b0-492a-820e-d0a6ebab6e36">
                 <component drugCode="R150" dose="1" units="tab" frequency="OD" />
                 <!--<component drugCode="H50" dose="1" units="tab" frequency="OD" />


### PR DESCRIPTION
Add RHZE as a regimen in the TB Regimen history for the children. Currently the regimen is lacking. The regimen should be added in the intensive phase (child) list.