### PR TITLE
In the MCH Antenatal Visit form, retain the previous height recorded

### DIFF
--- a/omod/src/main/webapp/resources/htmlforms/mchms/mchmsAntenatalVisit.html
+++ b/omod/src/main/webapp/resources/htmlforms/mchms/mchmsAntenatalVisit.html
@@ -61,6 +61,9 @@
     var LATEST_LMP_DATE =  "<lookup expression="fn.latestObs(1427).getValueDatetime()"/>";
     var LATEST_VISIT_NUMBER =  "<lookup expression="fn.latestObs(1425).getValueNumeric()"/>";
     var LATEST_VISIT_NUMBER_DATE =  "<lookup expression="fn.latestObs(1425).getObsDatetime()"/>";
+    var age = parseInt('<lookup expression="patient.age"/>');
+    var heightM = ("<lookup expression="fn.latestObs(5090).valueNumeric"/>");
+
     //Start on ready
 	jq(function () {
         jq('#anc-counselling').hide();
@@ -146,6 +149,12 @@
         }else{
             jq('#tbl-haart-given').hide();
 
+        }
+
+     	if (age &gt; 19 &amp;&amp; heightM !="" ) {
+                getField('height.value').val(heightM);
+            }else{
+                getField('height.value').val("");
         }
 
         if(HAART_START_DATE !="" || HAART_START_DATE != "false"){


### PR DESCRIPTION
In the MCH Antenatal Visit form, retain the previous height recorded for clients aged above 19 years as the height will never change.