### PR TITLE
Under HTS tracing (Physical tracing) form drop the option 'other'

### DIFF
--- a/omod/src/main/webapp/resources/htmlforms/hts/htsClientTracing.html
+++ b/omod/src/main/webapp/resources/htmlforms/hts/htsClientTracing.html
@@ -247,14 +247,12 @@
                                                                 160415,
                                                                 1706,
                                                                 1567,
-                                                                160034,
-                                                                5622"
+                                                                160034"
                                              answerLabels="No locator information,
                                                            Incorrect locator information,
                                                            Migrated,
                                                            Not found at home,
-                                                           Died,
-                                                           Others"
+                                                           Died"
                                              style="dropdown" />
                                     </td>
                                 </tr>


### PR DESCRIPTION
Under HTS tracing (Physical tracing) form drop the option 'other' under reason not contacted and where 'others' is selected provide a free text field to specify