### PR TITLE
client eligible for cervical cancer screening age 24-49 

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/CaCxScreeningCalculation.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/CaCxScreeningCalculation.java
@@ -1,0 +1,86 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.kenyaemr.calculation.library;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.*;
+import org.openmrs.api.ConceptService;
+import org.openmrs.api.PatientService;
+import org.openmrs.api.context.Context;
+import org.openmrs.calculation.patient.PatientCalculationContext;
+import org.openmrs.calculation.result.CalculationResultMap;
+import org.openmrs.module.kenyacore.calculation.AbstractPatientCalculation;
+import org.openmrs.module.kenyacore.calculation.BooleanResult;
+import org.openmrs.module.kenyacore.calculation.Filters;
+import org.openmrs.module.kenyaemr.metadata.CommonMetadata;
+import org.openmrs.module.kenyaemr.util.EmrUtils;
+import org.openmrs.module.metadatadeploy.MetadataUtils;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import static org.openmrs.module.kenyaemr.calculation.EmrCalculationUtils.daysSince;
+
+public class CaCxScreeningCalculation extends AbstractPatientCalculation {
+    protected static final Log log = LogFactory.getLog(CaCxScreeningCalculation.class);
+    public static final EncounterType cacxEncType = MetadataUtils.existing(EncounterType.class, CommonMetadata._EncounterType.CACX_SCREENING);
+    public static final EncounterType cacxAscEncType = MetadataUtils.existing(EncounterType.class, CommonMetadata._EncounterType.CACX_SCREENING);
+    public static final Form cacxScreeningForm = MetadataUtils.existing(Form.class, CommonMetadata._Form.CACX_SCREENING_FORM);
+    public static final Form cacxAscForm = MetadataUtils.existing(Form.class, CommonMetadata._Form.CACX_ASSESSMENT_FORM);
+    public static final Integer CACX_TEST_RESULT_QUESTION_CONCEPT_ID = 164934;
+    public static final Integer CACX_SCREEENING_METHOD_QUESTION_CONCEPT_ID = 163589;
+    Integer NOT_DONE = 1066;
+    Integer NEGATIVE = 664;
+    Integer HPV_TEST_CONCEPT_ID = 159859;
+
+    @Override
+    public CalculationResultMap evaluate(Collection<Integer> cohort, Map<String, Object> params, PatientCalculationContext context) {
+        Set<Integer> aliveAndFemale = Filters.female(Filters.alive(cohort, context), context);
+        CalculationResultMap ret = new CalculationResultMap();
+        PatientService patientService = Context.getPatientService();
+        for(Integer ptId:aliveAndFemale) {
+            Patient patient = patientService.getPatient(ptId);
+            boolean needsCacxTest = false;
+            ConceptService cs = Context.getConceptService();
+            Concept cacxTestResultQuestion = cs.getConcept(CACX_TEST_RESULT_QUESTION_CONCEPT_ID);
+            Concept cacxNotDoneResult = cs.getConcept(NOT_DONE);
+            Concept cacxNegativeResult = cs.getConcept(NEGATIVE);
+            Concept cacxHpvScreeningMethod = cs.getConcept(HPV_TEST_CONCEPT_ID);
+            Concept cacxScreeningMethodQuestion = cs.getConcept(CACX_SCREEENING_METHOD_QUESTION_CONCEPT_ID);
+
+
+            Encounter lastCacxScreeningEnc = EmrUtils.lastEncounter(patient, cacxEncType, cacxScreeningForm);
+            Encounter lastCacxAscEnc = EmrUtils.lastEncounter(patient, cacxAscEncType, cacxAscForm);
+
+            boolean patientHasNotDoneTestResult = lastCacxAscEnc != null ? EmrUtils.encounterThatPassCodedAnswer(lastCacxAscEnc, cacxTestResultQuestion, cacxNotDoneResult) : false;
+            boolean patientHasNegativeTestResult = lastCacxScreeningEnc != null ? EmrUtils.encounterThatPassCodedAnswer(lastCacxScreeningEnc, cacxTestResultQuestion, cacxNegativeResult) : false;
+            boolean patientScreenedUsingHPV = lastCacxScreeningEnc != null ? EmrUtils.encounterThatPassCodedAnswer(lastCacxScreeningEnc, cacxScreeningMethodQuestion, cacxHpvScreeningMethod) : false;
+
+            if(patient.getAge() >= 25 && patient.getAge() <= 49) {
+                if (lastCacxAscEnc != null && patientHasNotDoneTestResult ){
+                    needsCacxTest = true;
+                }
+
+                if(lastCacxScreeningEnc != null && !patientScreenedUsingHPV && patientHasNegativeTestResult && (daysSince(lastCacxScreeningEnc.getEncounterDatetime(), context) >= 365)) {
+                    needsCacxTest = true;
+                }
+                if(lastCacxScreeningEnc != null && patientScreenedUsingHPV && patientHasNegativeTestResult && (daysSince(lastCacxScreeningEnc.getEncounterDatetime(), context) >= 730)) {
+                    needsCacxTest = true;
+                }
+
+            }
+            ret.put(ptId, new BooleanResult(needsCacxTest, this));
+        }
+
+        return ret;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/kenyaemr/reporting/builder/common/PublicHealthActionReportBuilder.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/reporting/builder/common/PublicHealthActionReportBuilder.java
@@ -76,6 +76,7 @@ public class PublicHealthActionReportBuilder extends AbstractReportBuilder {
         cohortDsd.addColumn("PNS Contacts with undocumented HIV status", " (Please run PNS contacts with undocumented HIV status for linelist)", ReportUtils.map(publicHealthActionIndicatorLibrary.contactsUndocumentedHIVStatus(), "startDate=${startDate},endDate=${endDate}"), "");
         cohortDsd.addColumn("SNS Contacts with undocumented HIV status", " (Please run SNS contacts with undocumented HIV status for linelist)", ReportUtils.map(publicHealthActionIndicatorLibrary.snsContactsUndocumentedHIVStatus(), "startDate=${startDate},endDate=${endDate}"), "");
         cohortDsd.addColumn("Number of deaths", " (Please run mortality linelist for details)", ReportUtils.map(publicHealthActionIndicatorLibrary.numberOfDeaths(), "startDate=${startDate},endDate=${endDate}"), "");
+        cohortDsd.addColumn("Cervical cancer screening", " (Please run client eligible for cervical cancer screening age 24-49 for linelist)", ReportUtils.map(publicHealthActionIndicatorLibrary.cacxScreening(), "startDate=${startDate},endDate=${endDate}"), "");
 
         return cohortDsd;
 

--- a/api/src/main/java/org/openmrs/module/kenyaemr/reporting/library/ETLReports/publicHealthActionReport/PublicHealthActionCohortLibrary.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/reporting/library/ETLReports/publicHealthActionReport/PublicHealthActionCohortLibrary.java
@@ -10,6 +10,8 @@
 package org.openmrs.module.kenyaemr.reporting.library.ETLReports.publicHealthActionReport;
 
 import org.openmrs.module.kenyacore.report.ReportUtils;
+import org.openmrs.module.kenyacore.report.cohort.definition.CalculationCohortDefinition;
+import org.openmrs.module.kenyaemr.calculation.library.CaCxScreeningCalculation;
 import org.openmrs.module.kenyaemr.reporting.library.ETLReports.RevisedDatim.DatimCohortLibrary;
 import org.openmrs.module.reporting.cohort.definition.CohortDefinition;
 import org.openmrs.module.reporting.cohort.definition.CompositionCohortDefinition;
@@ -936,6 +938,13 @@ public class PublicHealthActionCohortLibrary {
                 ReportUtils.map(covid19AssessedPatients(), "startDate=${startDate},endDate=${endDate}"));
         cd.addSearch("covidVaccineAgeCohort", ReportUtils.map(covidVaccineAgeCohort(), "startDate=${startDate},endDate=${endDate}"));
         cd.setCompositionString("txcurr AND covidVaccineAgeCohort AND NOT covid19AssessedPatients");
+        return cd;
+    }
+    public CohortDefinition cacxScreening() {
+        CalculationCohortDefinition cd = new CalculationCohortDefinition(new CaCxScreeningCalculation());
+        cd.setName("eligible for cacx screening");
+        cd.addParameter(new Parameter("startDate", "Start Date", Date.class));
+        cd.addParameter(new Parameter("endDate", "End Date", Date.class));
         return cd;
     }
 }

--- a/api/src/main/java/org/openmrs/module/kenyaemr/reporting/library/ETLReports/publicHealthActionReport/PublicHealthActionIndicatorLibrary.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/reporting/library/ETLReports/publicHealthActionReport/PublicHealthActionIndicatorLibrary.java
@@ -95,6 +95,11 @@ public class PublicHealthActionIndicatorLibrary {
     public CohortIndicator heiMissedHIVTests() {
         return cohortIndicator("HEIs Missed HIV tests", ReportUtils.map(cohortLibrary.heiMissedHIVTests(), "startDate=${startDate},endDate=${endDate}"));
     }
+    public CohortIndicator cacxScreening() {
+        return cohortIndicator("CACX SCREENING", ReportUtils.map(cohortLibrary.cacxScreening(), "startDate=${startDate},endDate=${endDate}"));
+    }
+
+
     /**
      * Number of adolescents not in OTZ
      * @return the indicator


### PR DESCRIPTION
Provide a line list of clients eligible for cervical cancer screening - Age 25 to 49 on clinical report
It should include
1. Women within this age group who have never been screened for cervical cancer
2.Women within this age group who have had a screening done before but they are due for another screening based on the previous screening test and result
3.For clients previously screened using any other method except HPV and they had a negative result, they are eligible for rescreening after 12 months
4. For clients previously screened using HPV test and had a Negative result, they are eligible for rescreening after 2 years
![clinical_report](https://github.com/palladiumkenya/openmrs-module-kenyaemr/assets/8075969/cced6259-2643-48bd-9de2-1c27a69d5350)
