### PR TITLE
(enhancement) Removed completed forms from the returned results in adoption to UI Changes

### DIFF
--- a/omod/src/main/java/org/openmrs/module/kenyaemr/web/controller/KenyaemrCoreRestController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemr/web/controller/KenyaemrCoreRestController.java
@@ -250,17 +250,6 @@ public class KenyaemrCoreRestController extends BaseRestController {
                     }
                 }
             }
-
-            List<FormDescriptor> completedFormDescriptors = formManager.getCompletedFormsForVisit(patientVisit);
-
-            if (!completedFormDescriptors.isEmpty()) {
-
-                for (FormDescriptor descriptor : completedFormDescriptors) {
-                    ObjectNode formObj = generateFormDescriptorPayload(descriptor);
-                    formObj.put("formCategory", "completed");
-                    formList.add(formObj);
-                }
-            }
         }
 
         allFormsObj.put("results", formList);


### PR DESCRIPTION
### What does this PR do

I have removed the completed forms from the endpoint. The reason for this is that on o3, on launching the forms, we will only show the available forms on the `form dashboard`. To view completed forms, users will have to navigate to the visits tab and see all the forms they have filled out from that Tab. 


cc @CynthiaKamau @makombe @ojwanganto 