### PR TITLE
clients eligible for cervical cancer screening' - Age 25 to 49

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/hiv/CervicalCancerScreeningCalculation.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/hiv/CervicalCancerScreeningCalculation.java
@@ -1,2 +1,94 @@
-package org.openmrs.module.kenyaemr.calculation.library.hiv;public class CervicalCancerScreeningCalculation {
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.kenyaemr.calculation.library.hiv;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.*;
+import org.openmrs.api.ConceptService;
+import org.openmrs.api.PatientService;
+import org.openmrs.api.context.Context;
+import org.openmrs.calculation.patient.PatientCalculationContext;
+import org.openmrs.calculation.result.CalculationResultMap;
+import org.openmrs.module.kenyacore.calculation.AbstractPatientCalculation;
+import org.openmrs.module.kenyacore.calculation.BooleanResult;
+import org.openmrs.module.kenyacore.calculation.Filters;
+import org.openmrs.module.kenyaemr.metadata.CommonMetadata;
+import org.openmrs.module.kenyaemr.metadata.HivMetadata;
+import org.openmrs.module.kenyaemr.util.EmrUtils;
+import org.openmrs.module.metadatadeploy.MetadataUtils;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import static org.openmrs.module.kenyaemr.calculation.EmrCalculationUtils.daysSince;
+
+/*
+* Women within this age group who have never been screened for cervical cancer
+* Women within this age group who have had a screening done before but they are due for another screening based on the previous screening test and result
+* For clients previously screened using any other method except HPV and they had a negative result, they are eligible for rescreening after 12 months
+* For clients previously screened using HPV test and had a Negative result, they are eligible for re screening after 2 years
+*
+* */
+public class CervicalCancerScreeningCalculation extends AbstractPatientCalculation {
+    protected static final Log log = LogFactory.getLog(CervicalCancerScreeningCalculation.class);
+    public static final EncounterType cacxEncType = MetadataUtils.existing(EncounterType.class, CommonMetadata._EncounterType.CACX_SCREENING);
+    public static final Form cacxScreeningForm = MetadataUtils.existing(Form.class, CommonMetadata._Form.CACX_SCREENING_FORM);
+    public static final Integer CACX_TEST_RESULT_QUESTION_CONCEPT_ID = 164934;
+    public static final Integer CACX_SCREEENING_METHOD_QUESTION_CONCEPT_ID = 163589;
+    Integer NEGATIVE = 664;
+    Integer HPV_TEST_CONCEPT_ID = 159859;
+    Integer NORMAL = 1115;
+    @Override
+    public CalculationResultMap evaluate(Collection<Integer> cohort, Map<String, Object> params, PatientCalculationContext context) {
+        Set<Integer> aliveAndFemale = Filters.female(Filters.alive(cohort, context), context);
+        Program hivProgram = MetadataUtils.existing(Program.class, HivMetadata._Program.HIV);
+        Set<Integer> alive = Filters.alive(cohort, context);
+        Set<Integer> inHivProgram = Filters.inProgram(hivProgram, alive, context);
+        CalculationResultMap ret = new CalculationResultMap();
+        PatientService patientService = Context.getPatientService();
+        for(Integer ptId:aliveAndFemale) {
+            Patient patient = patientService.getPatient(ptId);
+            boolean needsCacxTest = false;
+            ConceptService cs = Context.getConceptService();
+            Concept cacxTestResultQuestion = cs.getConcept(CACX_TEST_RESULT_QUESTION_CONCEPT_ID);
+            Concept cacxNegativeResult = cs.getConcept(NEGATIVE);
+            Concept cacxHpvScreeningMethod = cs.getConcept(HPV_TEST_CONCEPT_ID);
+            Concept cacxScreeningMethodQuestion = cs.getConcept(CACX_SCREEENING_METHOD_QUESTION_CONCEPT_ID);
+            Concept cacxNormalResult = cs.getConcept(NORMAL);
+
+
+            Encounter lastCacxScreeningEnc = EmrUtils.lastEncounter(patient, cacxEncType, cacxScreeningForm);
+            boolean patientHasNegativeTestResult = lastCacxScreeningEnc != null ? EmrUtils.encounterThatPassCodedAnswer(lastCacxScreeningEnc, cacxTestResultQuestion, cacxNegativeResult) : false;
+            boolean patientScreenedUsingHPV = lastCacxScreeningEnc != null ? EmrUtils.encounterThatPassCodedAnswer(lastCacxScreeningEnc, cacxScreeningMethodQuestion, cacxHpvScreeningMethod) : false;
+            boolean patientHasNormalTestResult = lastCacxScreeningEnc != null ? EmrUtils.encounterThatPassCodedAnswer(lastCacxScreeningEnc, cacxTestResultQuestion, cacxNormalResult) : false;
+
+            if(patient.getAge() >= 25 && patient.getAge() <= 49) {
+                if (inHivProgram.contains(ptId)) {
+                    if (lastCacxScreeningEnc == null) {
+                        needsCacxTest = true;
+                    }
+
+                    if (lastCacxScreeningEnc != null && patientScreenedUsingHPV && patientHasNegativeTestResult && (daysSince(lastCacxScreeningEnc.getEncounterDatetime(), context) >= 730)) {
+                        needsCacxTest = true;
+                    }
+                    if (lastCacxScreeningEnc != null && !patientScreenedUsingHPV && (patientHasNegativeTestResult || patientHasNormalTestResult) && (daysSince(lastCacxScreeningEnc.getEncounterDatetime(), context) >= 365)) {
+                        needsCacxTest = true;
+                    }
+                }
+
+            }
+            ret.put(ptId, new BooleanResult(needsCacxTest, this));
+        }
+
+        return ret;
+    }
 }

--- a/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/hiv/CervicalCancerScreeningCalculation.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/calculation/library/hiv/CervicalCancerScreeningCalculation.java
@@ -1,0 +1,2 @@
+package org.openmrs.module.kenyaemr.calculation.library.hiv;public class CervicalCancerScreeningCalculation {
+}

--- a/api/src/main/java/org/openmrs/module/kenyaemr/reporting/builder/common/PublicHealthActionReportBuilder.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/reporting/builder/common/PublicHealthActionReportBuilder.java
@@ -76,7 +76,7 @@ public class PublicHealthActionReportBuilder extends AbstractReportBuilder {
         cohortDsd.addColumn("PNS Contacts with undocumented HIV status", " (Please run PNS contacts with undocumented HIV status for linelist)", ReportUtils.map(publicHealthActionIndicatorLibrary.contactsUndocumentedHIVStatus(), "startDate=${startDate},endDate=${endDate}"), "");
         cohortDsd.addColumn("SNS Contacts with undocumented HIV status", " (Please run SNS contacts with undocumented HIV status for linelist)", ReportUtils.map(publicHealthActionIndicatorLibrary.snsContactsUndocumentedHIVStatus(), "startDate=${startDate},endDate=${endDate}"), "");
         cohortDsd.addColumn("Number of deaths", " (Please run mortality linelist for details)", ReportUtils.map(publicHealthActionIndicatorLibrary.numberOfDeaths(), "startDate=${startDate},endDate=${endDate}"), "");
-
+        cohortDsd.addColumn("client eligible for Cervical cancer screening", " (client eligible for cervical cancer screening age 24-49 for linelist)", ReportUtils.map(publicHealthActionIndicatorLibrary.cervicalCancerScreening(), "startDate=${startDate},endDate=${endDate}"), "");
         return cohortDsd;
 
     }

--- a/api/src/main/java/org/openmrs/module/kenyaemr/reporting/library/ETLReports/publicHealthActionReport/PublicHealthActionCohortLibrary.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/reporting/library/ETLReports/publicHealthActionReport/PublicHealthActionCohortLibrary.java
@@ -10,6 +10,8 @@
 package org.openmrs.module.kenyaemr.reporting.library.ETLReports.publicHealthActionReport;
 
 import org.openmrs.module.kenyacore.report.ReportUtils;
+import org.openmrs.module.kenyacore.report.cohort.definition.CalculationCohortDefinition;
+import org.openmrs.module.kenyaemr.calculation.library.hiv.CervicalCancerScreeningCalculation;
 import org.openmrs.module.kenyaemr.reporting.library.ETLReports.RevisedDatim.DatimCohortLibrary;
 import org.openmrs.module.reporting.cohort.definition.CohortDefinition;
 import org.openmrs.module.reporting.cohort.definition.CompositionCohortDefinition;
@@ -937,5 +939,19 @@ public class PublicHealthActionCohortLibrary {
         cd.addSearch("covidVaccineAgeCohort", ReportUtils.map(covidVaccineAgeCohort(), "startDate=${startDate},endDate=${endDate}"));
         cd.setCompositionString("txcurr AND covidVaccineAgeCohort AND NOT covid19AssessedPatients");
         return cd;
+    }
+    public CohortDefinition cervicalCancerScreening() {
+        CalculationCohortDefinition cacx = new CalculationCohortDefinition(new CervicalCancerScreeningCalculation());
+        cacx.setName("eligible for cacx screening");
+        cacx.addParameter(new Parameter("startDate", "Start Date", Date.class));
+        cacx.addParameter(new Parameter("endDate", "End Date", Date.class));
+
+        CompositionCohortDefinition cohortCd2 = new CompositionCohortDefinition();
+        cohortCd2.addParameter(new Parameter("startDate", "Start Date", Date.class));
+        cohortCd2.addParameter(new Parameter("endDate", "End Date", Date.class));
+        cohortCd2.addSearch("txcurr", ReportUtils.map(datimCohortLibrary.currentlyOnArt(), "startDate=${startDate},endDate=${endDate}"));
+        cohortCd2.addSearch("cacx", ReportUtils.map((CohortDefinition) cacx, "startDate=${startDate},endDate=${endDate}"));
+        cohortCd2.setCompositionString("txcurr AND cacx");
+        return cohortCd2;
     }
 }

--- a/api/src/main/java/org/openmrs/module/kenyaemr/reporting/library/ETLReports/publicHealthActionReport/PublicHealthActionIndicatorLibrary.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/reporting/library/ETLReports/publicHealthActionReport/PublicHealthActionIndicatorLibrary.java
@@ -172,5 +172,8 @@ public class PublicHealthActionIndicatorLibrary {
     public CohortIndicator notAssessedForCovid19() {
         return cohortIndicator("Number of patients not assessed for Covid-19", ReportUtils.map(cohortLibrary.notAssessedForCovid19(), "startDate=${startDate},endDate=${endDate}"));
     }
+    public CohortIndicator cervicalCancerScreening() {
+        return cohortIndicator("CACX SCREENING", ReportUtils.map(cohortLibrary.cervicalCancerScreening(), "startDate=${startDate},endDate=${endDate}"));
+    }
 
 }


### PR DESCRIPTION
Add this  to the Clinical action report

It should include

Women within this age group who have never been screened for cervical cancer

Women within this age group who have had a screening done before but they are due for another screening based on the previous screening test and result

For clients previously screened using any other method except HPV and they had a negative result, they are eligible for rescreening after 12 months

For clients previously screened using HPV test and had a Negative result, they are eligible for rescreening after 2 years

NB: The client must be enrolled in HIV program and currently active on ART