### PR TITLE
(fix) Update discontinuationFormName to correct value

### DIFF
--- a/omod/src/main/java/org/openmrs/module/kenyaemr/web/controller/KenyaemrCoreRestController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemr/web/controller/KenyaemrCoreRestController.java
@@ -1479,7 +1479,7 @@ public class KenyaemrCoreRestController extends BaseRestController {
                     programDetails.put("enrollmentFormUuid", VMMCMetadata._Form.VMMC_ENROLLMENT_FORM);
                     programDetails.put("enrollmentFormName", "VMMC Enrollment Form");
                     programDetails.put("discontinuationFormUuid", VMMCMetadata._Form.VMMC_DISCONTINUATION_FORM);
-                    programDetails.put("discontinuationFormUuid", "VMMC Discontinuation Form");
+                    programDetails.put("discontinuationFormName", "VMMC Discontinuation Form");
                 }
 
                 // prep program


### PR DESCRIPTION
### Description:
**Issue Fixed:** The PR addresses a loading issue with the VMMC Discontinuation form in KenyaEMR 3.x. Previously, the form failed to load due to a problem in retrieving the formUuid.

**Root Cause:** The issue stemmed from an erroneous override of the formUuid by an appended formUuid value, which should have been the form name instead.