### PR TITLE
add configuration to control refresh of facility list on startup

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/EmrConstants.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/EmrConstants.java
@@ -67,4 +67,6 @@ public class EmrConstants {
 	public static final String DEFAULT_SUPPORT_PHONE_NUMBER = "0800 722 440";
 	public static final String DEFAULT_SUPPORT_EMAIL_ADDRESS = "help@palladiumgroup.on.spiceworks.com";
 	public static final String DEFAULT_EXTERNAL_HELP_URL = "/help";
+
+	public static final String GP_CONFIGURE_FACILITY_LIST_REFRESH_ON_STARTUP = "kenyaemr.refresh.facility.metadata";
 }

--- a/api/src/main/java/org/openmrs/module/kenyaemr/metadata/FacilityMetadata.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/metadata/FacilityMetadata.java
@@ -9,9 +9,13 @@
  */
 package org.openmrs.module.kenyaemr.metadata;
 
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Location;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.context.Context;
 import org.openmrs.customdatatype.datatype.FreeTextDatatype;
 import org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype;
+import org.openmrs.module.kenyaemr.EmrConstants;
 import org.openmrs.module.kenyaemr.metadata.sync.LocationMflCsvSource;
 import org.openmrs.module.kenyaemr.metadata.sync.LocationMflSynchronization;
 import org.openmrs.module.metadatadeploy.bundle.AbstractMetadataBundle;
@@ -48,7 +52,14 @@ public class FacilityMetadata extends AbstractMetadataBundle {
 	 */
 	@Override
 	public void install() throws Exception {
-		install(true);
+		AdministrationService administrationService = Context.getAdministrationService();
+		final String refreshConfig = (administrationService.getGlobalProperty(EmrConstants.GP_CONFIGURE_FACILITY_LIST_REFRESH_ON_STARTUP));
+
+		if (StringUtils.isNotEmpty(refreshConfig) && refreshConfig.equalsIgnoreCase("true")) {
+			install(true);
+		} else {
+			System.out.println("Skipping refreshing of the facility list ...");
+		}
 	}
 
 	/**

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -169,4 +169,12 @@
 		</description>
 	</globalProperty>
 
+	<globalProperty>
+		<property>kenyaemr.refresh.facility.metadata</property>
+		<defaultValue>false</defaultValue>
+		<description>
+			Configures refresh of the facility metadata during EMR startup. Valid values are true or false
+		</description>
+	</globalProperty>
+
 </module>


### PR DESCRIPTION
Controls wether to run or skip the sync for facilities based on the location list in the EMR