### PR TITLE
(feat) exclude O3 privileges from being added to `All Privileges` set  in metadata deploy

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/metadata/SecurityMetadata.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/metadata/SecurityMetadata.java
@@ -353,7 +353,7 @@ public class SecurityMetadata extends AbstractMetadataBundle {
 		Set<String> privileges = new HashSet<String>();
 
 		for (Privilege privilege : userService.getAllPrivileges()) {
-			if (privilege.getPrivilege().startsWith("App: ") || privilege.getPrivilege().startsWith("Emr: ")) {
+			if (privilege.getPrivilege().startsWith("App: ") || privilege.getPrivilege().startsWith("Emr: ") || privilege.getPrivilege().startsWith("o3: ")) {
 				continue;
 			}
 


### PR DESCRIPTION
## Description

This PR ensures the exclusion of O3 privileges from being automatically added to the API Privileges role during metadata deployment. This modification allows for a more flexible configuration of privileges, preventing any overlap with the API Privileges role. Currently, all additional privileges generated through the Init module (see [here](https://github.com/palladiumkenya/openmrs-config-kenyaemr/blob/main/configuration/privileges/privileges.csv)) are appended to the API Privileges role, causing challenges in configuring O3 to align with the correct roles and their respective privileges.

I have add a check with privileges starting with `o3` should be excluded. Am open to a better approach to make it work. @makombe @ojwanganto @PatrickWaweru @patryllus 