### PR TITLE
refined configs for ehcache

### DIFF
--- a/api/src/main/resources/apiCacheConfig.properties
+++ b/api/src/main/resources/apiCacheConfig.properties
@@ -1,3 +1,6 @@
 patientFlagCache.maxElementsInMemory=1000
-patientFlagCache.eternal=true
+patientFlagCache.eternal=false
 patientFlagCache.overflowToDisk=true
+patientFlagCache.timeToIdleSeconds=10800
+patientFlagCache.timeToLiveSeconds=10800
+patientFlagCache.maxElementsOnDisk=2000


### PR DESCRIPTION
This PR adds:
1. Config to keep cache for 3 hours i.e. 3600 x 3
2. Set overflow to disk if elements in cache are more than 1k
