### PR TITLE
(feat) : update `KDOD Service Number` to `Service Number` & and add `Publication No`

### DIFF
--- a/api/src/main/distro/metadata/identifierTypes.xml
+++ b/api/src/main/distro/metadata/identifierTypes.xml
@@ -31,4 +31,5 @@
 	<ref key="RECENCY_TESTING_ID" uuid="fd52829a-75d2-4732-8e43-4bff8e5b4f1a" />
 	<ref key="SOCIAL_HEALTH_INSURANCE_NUMBER" uuid="52c3c0c3-05b8-4b26-930e-2a6a54e14c90" />
 	<ref key="SHA_UNIQUE_IDENTIFICATION_NUMBER" uuid="24aedd37-b5be-4e08-8311-3721b8d5100d" />
+	<ref key="KDOD_PUBLICATION_NUMBER" uuid="5aa75418-75f8-4ad7-a7d8-8a24f6d3a2bb" />
 </refs>

--- a/api/src/main/java/org/openmrs/module/kenyaemr/metadata/CommonMetadata.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/metadata/CommonMetadata.java
@@ -133,6 +133,7 @@ public class CommonMetadata extends AbstractMetadataBundle {
 		public static final String RECENCY_TESTING_ID = Metadata.IdentifierType.RECENCY_TESTING_ID;
 		public static final String SOCIAL_HEALTH_INSURANCE_NUMBER = Metadata.IdentifierType.SOCIAL_HEALTH_INSURANCE_NUMBER;
 		public static final String SHA_UNIQUE_IDENTIFICATION_NUMBER = Metadata.IdentifierType.SHA_UNIQUE_IDENTIFICATION_NUMBER;
+		public static final String PUBLICATION_NUMBER= Metadata.IdentifierType.PUBLICATION_NUMBER;
 	}
 
 	public static final class _PersonAttributeType {
@@ -352,7 +353,7 @@ public class CommonMetadata extends AbstractMetadataBundle {
 		install(patientIdentifierType("CWC Number", "Assigned to a child patient when enrolling into the Child Welfare Clinic (CWC)",
 				".{1,14}", "Should take the format (CWC-MFL code-serial number) e.g CWC-15007-00001", null,
 				LocationBehavior.NOT_USED, false, _PatientIdentifierType.CWC_NUMBER));
-		install(patientIdentifierType("KDoD service number", "Unique Id for KDoD service men", "^[0-9]{5,6}$|^[0-9]{5,6}\\/[0-9]{2}$", "Must be a 5-6 digit number (for principal) or 5-6 digit number followed by / and 2 digits (for dependant)",
+		install(patientIdentifierType("Service number", "Unique Id for KDoD service men", "^[0-9]{5,6}$|^[0-9]{5,6}\\/[0-9]{2}$", "Must be a 5-6 digit number (for principal) or 5-6 digit number followed by / and 2 digits (for dependant)",
 				null, LocationBehavior.NOT_USED, false, _PatientIdentifierType.KDoD_SERVICE_NUMBER));
 
 		install(patientIdentifierType("Client Number", "A partner specific identification for clients", "", "",
@@ -373,6 +374,8 @@ public class CommonMetadata extends AbstractMetadataBundle {
 				null, LocationBehavior.NOT_USED, false, _PatientIdentifierType.SOCIAL_HEALTH_INSURANCE_NUMBER));
 		install(patientIdentifierType("Social Health Authority Identification Number", "Social Health Authority Unique Identification Number", "", "Allows for alphanumeric format",
 			null, LocationBehavior.NOT_USED, false, _PatientIdentifierType.SHA_UNIQUE_IDENTIFICATION_NUMBER));
+		install(patientIdentifierType("Publication Number", "Uniquely identifies military dependents, aiding in organizing and linking them to service members", "", "Allows for alphanumeric format",
+			null, LocationBehavior.NOT_USED, false, _PatientIdentifierType.PUBLICATION_NUMBER));
 
 
 

--- a/api/src/main/java/org/openmrs/module/kenyaemr/metadata/CommonMetadata.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/metadata/CommonMetadata.java
@@ -133,7 +133,7 @@ public class CommonMetadata extends AbstractMetadataBundle {
 		public static final String RECENCY_TESTING_ID = Metadata.IdentifierType.RECENCY_TESTING_ID;
 		public static final String SOCIAL_HEALTH_INSURANCE_NUMBER = Metadata.IdentifierType.SOCIAL_HEALTH_INSURANCE_NUMBER;
 		public static final String SHA_UNIQUE_IDENTIFICATION_NUMBER = Metadata.IdentifierType.SHA_UNIQUE_IDENTIFICATION_NUMBER;
-		public static final String PUBLICATION_NUMBER= Metadata.IdentifierType.PUBLICATION_NUMBER;
+		public static final String KDOD_PUBLICATION_NUMBER= Metadata.IdentifierType.KDOD_PUBLICATION_NUMBER;
 	}
 
 	public static final class _PersonAttributeType {
@@ -375,7 +375,7 @@ public class CommonMetadata extends AbstractMetadataBundle {
 		install(patientIdentifierType("Social Health Authority Identification Number", "Social Health Authority Unique Identification Number", "", "Allows for alphanumeric format",
 			null, LocationBehavior.NOT_USED, false, _PatientIdentifierType.SHA_UNIQUE_IDENTIFICATION_NUMBER));
 		install(patientIdentifierType("Publication Number", "Uniquely identifies military dependents, aiding in organizing and linking them to service members", "", "Allows for alphanumeric format",
-			null, LocationBehavior.NOT_USED, false, _PatientIdentifierType.PUBLICATION_NUMBER));
+			null, LocationBehavior.NOT_USED, false, _PatientIdentifierType.KDOD_PUBLICATION_NUMBER));
 
 
 


### PR DESCRIPTION
### Description

This PR address request from KDOD through @mmatheka and andreline to 
1. Update name for KDOD Service number to Service Number 
2. Add a new identifier .i.e `Publication Number` that uniquely identifies military dependents, aiding in organizing and linking them to service members