### PR TITLE
Remove date_created filter on the appointment migration query

### DIFF
--- a/api/src/main/resources/MigrateAppointmentsFromObs.sql
+++ b/api/src/main/resources/MigrateAppointmentsFromObs.sql
@@ -1,7 +1,7 @@
 
 SET FOREIGN_KEY_CHECKS=0;
 delete from patient_appointment_audit;
-delete from patient_appointment where appointment_service_id is null or (appointment_service_id in (1,2,3,4,5,6,7,8,9,13,11,12) and date_created < '2024-04-25 18:00:00');
+delete from patient_appointment where appointment_service_id is null or (appointment_service_id in (1,2,3,4,5,6,7,8,9,13,11,12));
 SET FOREIGN_KEY_CHECKS=1;
     
     


### PR DESCRIPTION
This filter was useful not to delete appointment created through o3 for the o3 sites when doing migration.( **We hope all o3 sites have now aligned )**

But for sites that are stilling using 2x i.e site which still fill next appointment date on green card and not using the appointment launcher. These sites still have the appointment sync feature running on the background creating appointments and with that date cap means same appointments will still be migrated when they are transitioning to o3 using the liquibase feature we added.

The fix here is that for new site upgrading to o3, we clear the appointment table and migrate all appointments a fresh from the obs table.