### PR TITLE
add the missing caresetting when querying drug orders for TPT

### DIFF
--- a/omod/src/main/java/org/openmrs/module/kenyaemr/web/controller/KenyaemrCoreRestController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemr/web/controller/KenyaemrCoreRestController.java
@@ -1343,8 +1343,9 @@ public class KenyaemrCoreRestController extends BaseRestController {
                     }
                     try {
                         // get medication patient is on
+                        CareSetting outpatient = Context.getOrderService().getCareSettingByName("OUTPATIENT"); // TODO: include all relevant care settings
                         OrderType drugOrderType = Context.getOrderService().getOrderTypeByUuid(OrderType.DRUG_ORDER_TYPE_UUID);
-                        List<Order> allDrugOrders = Context.getOrderService().getOrders(patient, null, drugOrderType, false);
+                        List<Order> allDrugOrders = Context.getOrderService().getOrders(patient, outpatient, drugOrderType, false);
                         List<DrugOrder> tptDrugOrders = new ArrayList<DrugOrder>();
                         for (Order order : allDrugOrders) {
                             if (order != null && order.getConcept() != null) {


### PR DESCRIPTION
This PR adds the required caresetting parameter when querying the orders API. It resolves the below error:
`java.lang.IllegalArgumentException: CareSetting is required
	at org.openmrs.api.impl.OrderServiceImpl.getOrders(OrderServiceImpl.java:560)`