### PR TITLE
Add Dwapi metrics endpoint from psmart module

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/DwapiMetricsUtil.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/DwapiMetricsUtil.java
@@ -1,0 +1,84 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.kenyaemr;
+
+import org.apache.commons.lang3.StringUtils;
+import org.openmrs.Encounter;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.kenyaemr.metadata.HivMetadata;
+import org.openmrs.module.kenyaemr.util.EmrUtils;
+import org.openmrs.module.kenyaemr.util.ServerInformation;
+import org.openmrs.module.reporting.report.ReportRequest;
+import org.openmrs.module.reporting.report.definition.ReportDefinition;
+import org.openmrs.module.reporting.report.service.ReportService;
+import org.openmrs.util.OpenmrsUtil;
+
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+public class DwapiMetricsUtil {
+    public static String getKenyaemrVersion() {
+        //TODO: Read this from a global property:kenyaemr.version
+        Map<String, Object> kenyaemrInfo = ServerInformation.getKenyaemrInformation();
+        String moduleVersion = (String) kenyaemrInfo.get("version");
+        return moduleVersion;
+    }
+
+    public static String getLastLogin() {
+        SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MMM-dd");
+
+
+        Encounter lastFollowupEnc = EmrUtils.lastEncounter(null, Context.getEncounterService().getEncounterTypeByUuid(HivMetadata._EncounterType.HIV_CONSULTATION));
+        if (lastFollowupEnc != null) {
+            return DATE_FORMAT.format(lastFollowupEnc.getDateCreated());
+        }
+        return null;
+
+    }
+
+    public static String getDateofLastMOH731() {
+        String moh731ReportDefUuid = "a66bf454-2a11-4e51-b28d-3d7ece76aa13";
+        SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MMM-dd");
+        List<ReportRequest> reports = fetchRequests(moh731ReportDefUuid, true, Context.getService(ReportService.class));
+        if (reports != null && !reports.isEmpty()) {
+            return DATE_FORMAT.format(reports.get(0).getEvaluateStartDatetime());
+        }
+
+        return null;
+    }
+
+    public static List<ReportRequest> fetchRequests(String reportUuid, boolean finishedOnly, ReportService reportService) {
+        ReportDefinition definition = null;
+
+        // Hack to avoid loading (and thus de-serialising) the entire report
+        if (StringUtils.isNotEmpty(reportUuid)) {
+            definition = new ReportDefinition();
+            definition.setUuid(reportUuid);
+        }
+
+        List<ReportRequest> requests = (finishedOnly)
+                ? reportService.getReportRequests(definition, null, null, ReportRequest.Status.COMPLETED, ReportRequest.Status.FAILED)
+                : reportService.getReportRequests(definition, null, null);
+
+        // Sort by requested date desc (more sane than the default sorting)
+        Collections.sort(requests, new Comparator<ReportRequest>() {
+            @Override
+            public int compare(ReportRequest request1, ReportRequest request2) {
+                return OpenmrsUtil.compareWithNullAsEarliest(request2.getRequestDate(), request1.getRequestDate());
+            }
+        });
+
+        return requests;
+    }
+
+}

--- a/omod/src/main/java/org/openmrs/module/kenyaemr/web/controller/KenyaemrCoreRestController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemr/web/controller/KenyaemrCoreRestController.java
@@ -14,6 +14,7 @@ import org.openmrs.api.context.Context;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.PatientService;
+import org.openmrs.module.kenyaemr.DwapiMetricsUtil;
 import org.openmrs.module.kenyaemr.api.KenyaEmrService;
 import org.openmrs.calculation.result.CalculationResultMap;
 import org.openmrs.calculation.patient.PatientCalculationService;
@@ -2852,6 +2853,23 @@ else {
     public List<org.openmrs.module.webservices.rest.SimpleObject> search(@RequestParam("q") String query, HttpServletRequest request) throws Exception {
         return Context.getService(KenyaEmrService.class).search(query, request.getParameterMap());
 
+    }
+
+    /**
+     * Generates KenyaEMR related metrics
+     * @param request
+     * @return
+     */
+    @RequestMapping(method = RequestMethod.GET, value = "/getemrmetrics")
+    @ResponseBody
+    public Object getKenyaEMRDetails(HttpServletRequest request) {
+
+        return "{\n" +
+                "    \"EmrName\":\"KenyaEMR\",\n" +
+                "    \"EmrVersion\":\"" + DwapiMetricsUtil.getKenyaemrVersion() + "\",\n" +
+                "    \"LastLoginDate\":\"" + DwapiMetricsUtil.getLastLogin() + "\",\n" +
+                "    \"LastMoH731RunDate\":\"" + DwapiMetricsUtil.getDateofLastMOH731() + "\"" +
+                "}";
     }
 
     /**

--- a/omod/src/main/java/org/openmrs/module/kenyaemr/web/controller/KenyaemrCoreRestController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemr/web/controller/KenyaemrCoreRestController.java
@@ -2863,13 +2863,12 @@ else {
     @RequestMapping(method = RequestMethod.GET, value = "/getemrmetrics")
     @ResponseBody
     public Object getKenyaEMRDetails(HttpServletRequest request) {
-
-        return "{\n" +
-                "    \"EmrName\":\"KenyaEMR\",\n" +
-                "    \"EmrVersion\":\"" + DwapiMetricsUtil.getKenyaemrVersion() + "\",\n" +
-                "    \"LastLoginDate\":\"" + DwapiMetricsUtil.getLastLogin() + "\",\n" +
-                "    \"LastMoH731RunDate\":\"" + DwapiMetricsUtil.getDateofLastMOH731() + "\"" +
-                "}";
+        return SimpleObject.create(
+              "EmrName", "KenyaEMR",
+                "EmrVersion", DwapiMetricsUtil.getKenyaemrVersion(),
+                "LastLoginDate", DwapiMetricsUtil.getLastLogin(),
+                "LastMoH731RunDate", DwapiMetricsUtil.getDateofLastMOH731()
+        );
     }
 
     /**
@@ -2882,17 +2881,12 @@ else {
     public Object verifyNUPI(@PathVariable String country, @PathVariable String identifierType, @PathVariable String identifier) {
         String ret = "{\"status\": \"Error\"}";
         try {
-            System.out.println("NUPI verification: Country: " + country + " IdentifierType: " + identifierType + " Identifier: " + identifier);
-
-            // Create URL
-            // String baseURL = "https://afyakenyaapi.health.go.ke/partners/registry/search";
             GlobalProperty globalGetUrl = Context.getAdministrationService().getGlobalPropertyObject(CommonMetadata.GP_CLIENT_VERIFICATION_GET_END_POINT);
             String baseURL = globalGetUrl.getPropertyValue();
             if(baseURL == null || baseURL.trim().isEmpty()) {
-                baseURL = "https://afyakenyaapi.health.go.ke/partners/registry/search";
+                baseURL = "https://afyakenyaapi.health.go.ke/partners/registry/search";//TODO: we need to remove this ASAP
             }
             String completeURL = baseURL + "/"  + country + "/" + identifierType  + "/" + identifier;
-            System.out.println("NUPI verification: Using NUPI GET URL: " + completeURL);
             URL url = new URL(completeURL);
 
             UpiUtilsDataExchange upiUtilsDataExchange = new UpiUtilsDataExchange();


### PR DESCRIPTION
DWAPI metrics endpoint will be available at `<host>/openmrs/ws/rest/v1/kenyaemr/getemrmetrics`
The response looks like the below:
`{
    "EmrName": "KenyaEMR",
    "EmrVersion": "19.1.2",
    "LastLoginDate": "2024-Jul-26",
    "LastMoH731RunDate": null
}
`


@andrineM @Murithijoshua @RAJABIBRAZ please note that we'll not need to include the psmart module in our releases.