### PR TITLE
Revised TX CURR query to drop clients who have stopped treatment and …

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/reporting/cohort/definition/evaluator/ActivePatientsSnapshotCohortDefinitionEvaluator.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/reporting/cohort/definition/evaluator/ActivePatientsSnapshotCohortDefinitionEvaluator.java
@@ -51,7 +51,10 @@ public class ActivePatientsSnapshotCohortDefinitionEvaluator implements CohortDe
 		Cohort newCohort = new Cohort();
 
 		String qry="select t.patient_id\n" +
-				"from (select fup.visit_date,\n" +
+				"from (WITH MaxDrugEncounters AS\n" +
+				"    (\n" +
+				"    SELECT patient_id, MAX(encounter_id) AS max_encounter_id FROM kenyaemr_etl.etl_drug_event WHERE program = 'HIV' AND DATE(date_started) <= DATE(:endDate) GROUP BY patient_id)\n" +
+				"select fup.visit_date,\n" +
 				"             fup.patient_id,\n" +
 				"             max(e.visit_date)                                                                as enroll_date,\n" +
 				"             greatest(max(fup.visit_date), ifnull(max(d.visit_date), '0000-00-00'))           as latest_vis_date,\n" +
@@ -60,23 +63,26 @@ public class ActivePatientsSnapshotCohortDefinitionEvaluator implements CohortDe
 				"             d.patient_id                                                                     as disc_patient,\n" +
 				"             d.effective_disc_date                                                            as effective_disc_date,\n" +
 				"             max(d.visit_date)                                                                as date_discontinued,\n" +
-				"             de.patient_id                                                   as started_on_drugs\n" +
+				"             mid(max(concat((de.encounter_id), ifnull(de.discontinued, 0))), -1) as on_drugs\n" +
 				"      from kenyaemr_etl.etl_patient_hiv_followup fup\n" +
 				"               join kenyaemr_etl.etl_patient_demographics p on p.patient_id = fup.patient_id\n" +
 				"               join kenyaemr_etl.etl_hiv_enrollment e on fup.patient_id=e.patient_id\n" +
-				"                           left join kenyaemr_etl.etl_drug_event de\n" +
-				"                          on e.patient_id = de.patient_id and de.program = 'HIV' and date(de.date_started) <= date(:endDate)\n" +
+				"                           INNER JOIN\n" +
+				"                       MaxDrugEncounters mde ON e.patient_id = mde.patient_id\n" +
+				"                           INNER JOIN\n" +
+				"                       kenyaemr_etl.etl_drug_event de ON e.patient_id = de.patient_id\n" +
+				"                           AND mde.max_encounter_id = de.encounter_id\n" +
 				"               left outer JOIN\n" +
 				"           (select patient_id,\n" +
-				"                   coalesce(date(effective_discontinuation_date), visit_date) visit_date,\n" +
-				"                   max(date(effective_discontinuation_date)) as               effective_disc_date\n" +
+				"                   date(coalesce(NULLIF(LEAST(COALESCE(date(trf_out_verification_date),'9999-12-31'),COALESCE(date(effective_discontinuation_date),'9999-12-31')),'9999-12-31'), visit_date)) visit_date,\n" +
+				"                               NULLIF(LEAST(COALESCE(max(date(trf_out_verification_date)),'9999-12-31'),COALESCE(max(date(effective_discontinuation_date)),'9999-12-31')),'9999-12-31') as effective_disc_date\n" +
 				"            from kenyaemr_etl.etl_patient_program_discontinuation\n" +
 				"            where date(visit_date) <= date(:endDate)\n" +
 				"              and program_name = 'HIV'\n" +
 				"            group by patient_id) d on d.patient_id = fup.patient_id\n" +
 				"      where fup.visit_date <= date(:endDate)\n" +
-				"      group by patient_id\n" +
-				"      having (started_on_drugs is not null and started_on_drugs <> '')\n" +
+				"      group by fup.patient_id\n" +
+				"      having on_drugs != 1\n" +
 				"         and (\n" +
 				"          (\n" +
 				"                  (timestampdiff(DAY, date(latest_tca), date(:endDate)) <= 30 and\n" +

--- a/api/src/main/java/org/openmrs/module/kenyaemr/reporting/library/ETLReports/RevisedDatim/DatimCohortLibrary.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/reporting/library/ETLReports/RevisedDatim/DatimCohortLibrary.java
@@ -122,7 +122,10 @@ public class DatimCohortLibrary {
         SqlCohortDefinition cd = new SqlCohortDefinition();
 
         String sqlQuery = "select t.patient_id\n" +
-                "from (select fup.visit_date,\n" +
+                "from (WITH MaxDrugEncounters AS\n" +
+                "    (\n" +
+                "    SELECT patient_id, MAX(encounter_id) AS max_encounter_id FROM kenyaemr_etl.etl_drug_event WHERE program = 'HIV' AND DATE(date_started) <= DATE(:endDate) GROUP BY patient_id)\n" +
+                "select fup.visit_date,\n" +
                 "             fup.patient_id,\n" +
                 "             max(e.visit_date)                                                                as enroll_date,\n" +
                 "             greatest(max(fup.visit_date), ifnull(max(d.visit_date), '0000-00-00'))           as latest_vis_date,\n" +
@@ -131,23 +134,26 @@ public class DatimCohortLibrary {
                 "             d.patient_id                                                                     as disc_patient,\n" +
                 "             d.effective_disc_date                                                            as effective_disc_date,\n" +
                 "             max(d.visit_date)                                                                as date_discontinued,\n" +
-                "             de.patient_id                                                   as started_on_drugs\n" +
+                "             mid(max(concat((de.encounter_id), ifnull(de.discontinued, 0))), -1) as on_drugs\n" +
                 "      from kenyaemr_etl.etl_patient_hiv_followup fup\n" +
                 "               join kenyaemr_etl.etl_patient_demographics p on p.patient_id = fup.patient_id\n" +
                 "               join kenyaemr_etl.etl_hiv_enrollment e on fup.patient_id=e.patient_id\n" +
-                "                           left join kenyaemr_etl.etl_drug_event de\n" +
-                "                          on e.patient_id = de.patient_id and de.program = 'HIV' and date(de.date_started) <= date(:endDate)\n" +
+                "                           INNER JOIN\n" +
+                "                       MaxDrugEncounters mde ON e.patient_id = mde.patient_id\n" +
+                "                           INNER JOIN\n" +
+                "                       kenyaemr_etl.etl_drug_event de ON e.patient_id = de.patient_id\n" +
+                "                           AND mde.max_encounter_id = de.encounter_id\n" +
                 "               left outer JOIN\n" +
                 "           (select patient_id,\n" +
-                "                   coalesce(date(effective_discontinuation_date), visit_date) visit_date,\n" +
-                "                   max(date(effective_discontinuation_date)) as               effective_disc_date\n" +
+                "                   date(coalesce(NULLIF(LEAST(COALESCE(date(trf_out_verification_date),'9999-12-31'),COALESCE(date(effective_discontinuation_date),'9999-12-31')),'9999-12-31'), visit_date)) visit_date,\n" +
+                "                               NULLIF(LEAST(COALESCE(max(date(trf_out_verification_date)),'9999-12-31'),COALESCE(max(date(effective_discontinuation_date)),'9999-12-31')),'9999-12-31') as effective_disc_date\n" +
                 "            from kenyaemr_etl.etl_patient_program_discontinuation\n" +
                 "            where date(visit_date) <= date(:endDate)\n" +
                 "              and program_name = 'HIV'\n" +
                 "            group by patient_id) d on d.patient_id = fup.patient_id\n" +
                 "      where fup.visit_date <= date(:endDate)\n" +
-                "      group by patient_id\n" +
-                "      having (started_on_drugs is not null and started_on_drugs <> '')\n" +
+                "      group by fup.patient_id\n" +
+                "      having on_drugs != 1\n" +
                 "         and (\n" +
                 "          (\n" +
                 "                  (timestampdiff(DAY, date(latest_tca), date(:endDate)) <= 30 and\n" +


### PR DESCRIPTION
…use the earliest date between transfer out verification date and effective discontinuation date in determining when to stop considering the client for txcurr