### PR TITLE
(fix): Update female sex work concept to use ocl created concept

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/chore/UpdateFSWConcept.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/chore/UpdateFSWConcept.java
@@ -1,0 +1,30 @@
+package org.openmrs.module.kenyaemr.chore;
+
+import org.openmrs.api.context.Context;
+import org.openmrs.module.kenyacore.chore.AbstractChore;
+import org.springframework.stereotype.Component;
+
+import java.io.PrintWriter;
+/**
+ * update FSW concept from 165083 to 166513
+ */
+@Component("kenyaemr.chore.UpdateFSWConcept")
+public class UpdateFSWConcept extends AbstractChore {
+
+    /**
+     * @see AbstractChore#perform(PrintWriter)
+     */
+
+    @Override
+    public void perform(PrintWriter out) {
+        String updateConceptSql = "update obs set value_coded = 166513 where value_coded =165083;";
+        Context.getAdministrationService().executeSQL(updateConceptSql, false);
+        out.println("Completed updating FSW concept");
+
+    }
+
+
+
+
+}
+


### PR DESCRIPTION
We have noted that this concept `89828287-b96f-449c-b3ae-d518d55703e1` is corrupted and affecting loading of visits. Therefore, we are migrating it to `166513AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA.` All the data that was collected with the old concept will be moved to the new OCL one.

Link to [PR](https://github.com/palladiumkenya/openmrs-config-kenyaemr/pull/910)