### PR TITLE
Added back ability to flag a client who has not enrolled in any program

### DIFF
--- a/omod/src/main/java/org/openmrs/module/kenyaemr/web/controller/KenyaemrCoreRestController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemr/web/controller/KenyaemrCoreRestController.java
@@ -309,10 +309,11 @@ public class KenyaemrCoreRestController extends BaseRestController {
         ObjectNode flagsObj = JsonNodeFactory.instance.objectNode();
 
         // TODO: Consider flags categorization for a patient who is not in any program
-        if (programEnrolmentHistory.size() < 1) {
-            flagsObj.put("results", JsonNodeFactory.instance.arrayNode()); // return an empty list
-            return flagsObj.toString();
-        }
+		// TODO: Commenting this code to flag patients not in any program 
+//        if (programEnrolmentHistory.size() < 1) {
+//            flagsObj.put("results", JsonNodeFactory.instance.arrayNode()); // return an empty list
+//            return flagsObj.toString();
+//        }
 
         CacheManager cacheManager = Context.getRegisteredComponent("apiCacheManager", CacheManager.class);
         Cache patientFlagCache = cacheManager.getCache("patientFlagCache");


### PR DESCRIPTION
Current: Flagging currently works for patients enrolled in at least one program given this implementations. I take cognisance of the need to optimise flags which are hugely expensive. 

Issue: Facility wide patients/OPD, IDSR pateints who are not enrolled in any program cannot be flagged

Tentative Resolution: I have commented the section requiring a patient to be in a program for flagging to work

Ask: Kindly review and advice

