### PR TITLE
Clients transfer out report, shows facility transferred to as UUID instead of facility name

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/reporting/cohort/definition/evaluator/hiv/FacilityTransferToCohortDefinitionEvaluator.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/reporting/cohort/definition/evaluator/hiv/FacilityTransferToCohortDefinitionEvaluator.java
@@ -32,9 +32,10 @@ import java.util.Map;
 
 	public EvaluatedPersonData evaluate(PersonDataDefinition definition, EvaluationContext context) throws EvaluationException {
 		EvaluatedPersonData c = new EvaluatedPersonData(definition, context);
-
-		String qry = "select patient_id, transfer_facility from kenyaemr_etl.etl_patient_program_discontinuation;";
-
+		String qry = "SELECT d.patient_id,\n" +
+				"COALESCE(l.name, d.transfer_facility) AS transfer_facility\n" +
+				"FROM kenyaemr_etl.etl_patient_program_discontinuation d\n" +
+				"LEFT JOIN openmrs.location l ON d.transfer_facility COLLATE utf8mb3_general_ci = l.uuid;";
 		SqlQueryBuilder queryBuilder = new SqlQueryBuilder();
 		queryBuilder.append(qry);
 		Map<Integer, Object> data = evaluationService.evaluateToMap(queryBuilder, Integer.class, Object.class, context);


### PR DESCRIPTION
The client transfer out report shows the facility transferred to as UUID instead of the facility name
![Screenshot from 2025-05-09 19-37-29](https://github.com/user-attachments/assets/8262a04f-6a91-4c1d-b2be-47e388be1ec2)
![Screenshot from 2025-05-09 17-42-31](https://github.com/user-attachments/assets/1b6eb3fa-793c-405d-9744-9d407920d575)
