### PR TITLE
(fix) : ensure visit date format follow OpenMRS supported formats

### DIFF
--- a/omod/src/main/java/org/openmrs/module/kenyaemr/web/controller/KenyaemrCoreRestController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemr/web/controller/KenyaemrCoreRestController.java
@@ -321,7 +321,7 @@ public class KenyaemrCoreRestController extends BaseRestController {
 
         // Show available forms for retrospective data entry
         if(patient != null && !StringUtils.isBlank(visitEndDate) && !StringUtils.isBlank(visitStartDate) && activeVisits.isEmpty()) {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
             LocalDateTime endDateTime = LocalDateTime.parse(visitEndDate, formatter);
             LocalDateTime startDateTime = LocalDateTime.parse(visitStartDate, formatter);
             Date endDate = Date.from(endDateTime.atZone(ZoneId.systemDefault()).toInstant());


### PR DESCRIPTION
### Description
Update the visit date handling in the backend so that all incoming visitStartDate and visitEndDate values strictly adhere to the OpenMRS ISO-8601 format (yyyy-MM-dd'T'HH:mm:ss.SSSZ)