### PR TITLE
Fixes for case surveillance report and dashboard indicators

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/FacilityDashboardUtil.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/FacilityDashboardUtil.java
@@ -667,7 +667,7 @@ public class FacilityDashboardUtil {
 				"         LEFT JOIN (select o.patient_id,o.hiv_status_at_exit from kenyaemr_etl.etl_hei_enrollment o where o.encounter_type = 'MCHCS_HEI_COMPLETION'\n" +
 				"                                                                                                      and o.visit_date <= date('" + endDate + "')) o on o.patient_id = e.patient_id\n" +
 				"         left join kenyaemr_etl.etl_patient_program_discontinuation c\n" +
-				"                   on e.patient_id = c.patient_id and c.program_name = 'MCH Child HEI'\n" +
+				"                   on e.patient_id = c.patient_id and c.program_name in ('MCH Child HEI','MCH Child')\n" +
 				"         left join kenyaemr_etl.etl_hts_test t on t.patient_id = e.patient_id\n" +
 				"WHERE d.hei_no is not null\n" +
 				"  AND DATE_ADD(d.dob, INTERVAL 24 MONTH) BETWEEN DATE_SUB(date('" + endDate + "'), INTERVAL\n" +
@@ -1028,7 +1028,7 @@ public class FacilityDashboardUtil {
 				"                     LEFT JOIN (select o.patient_id,o.hiv_status_at_exit from kenyaemr_etl.etl_hei_enrollment o where o.encounter_type = 'MCHCS_HEI_COMPLETION'\n" +
 				"                                and o.visit_date <= CURRENT_DATE) o on o.patient_id = e.patient_id\n" +
 				"                     left join kenyaemr_etl.etl_patient_program_discontinuation c\n" +
-				"                               on e.patient_id = c.patient_id and c.program_name = 'MCH Child HEI'\n" +
+				"                               on e.patient_id = c.patient_id and c.program_name in ('MCH Child HEI','MCH Child')\n" +
 				"                     left join kenyaemr_etl.etl_hts_test t on t.patient_id = e.patient_id\n" +
 				"WHERE d.hei_no is not null\n" +
 				"  AND DATE_ADD(d.dob, INTERVAL 24 MONTH) BETWEEN DATE_SUB(CURRENT_DATE, INTERVAL 30 DAY) AND CURRENT_DATE\n" +

--- a/api/src/main/java/org/openmrs/module/kenyaemr/chore/UpdateMotherVLInCWCFupConcept.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/chore/UpdateMotherVLInCWCFupConcept.java
@@ -1,0 +1,42 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.kenyaemr.chore;
+
+import org.openmrs.api.context.Context;
+import org.openmrs.module.kenyacore.chore.AbstractChore;
+import org.springframework.stereotype.Component;
+
+import java.io.PrintWriter;
+
+/**
+ * update Mother VL concept from 856 to 163545
+ */
+@Component("kenyaemr.chore.UpdateMotherVLInCWCFupConcept")
+public class UpdateMotherVLInCWCFupConcept extends AbstractChore {
+
+    /**
+     * @see AbstractChore#perform(PrintWriter)
+     */
+
+    @Override
+    public void perform(PrintWriter out) {
+        String updateConceptSql = "UPDATE obs o\n" +
+                "    JOIN encounter e ON o.encounter_id = e.encounter_id\n" +
+                "    JOIN encounter_type et ON e.encounter_type = et.encounter_type_id\n" +
+                "SET o.concept_id = 163545\n" +
+                "WHERE o.concept_id = 856\n" +
+                "  AND et.uuid = 'bcc6da85-72f2-4291-b206-789b8186a021';";
+        Context.getAdministrationService().executeSQL(updateConceptSql, false);
+        out.println("Completed updating Mother VL concept in CWC followup");
+
+    }
+
+}
+

--- a/api/src/main/java/org/openmrs/module/kenyaemr/reporting/library/ETLReports/publicHealthActionReport/PublicHealthActionCohortLibrary.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/reporting/library/ETLReports/publicHealthActionReport/PublicHealthActionCohortLibrary.java
@@ -1186,7 +1186,7 @@ public class PublicHealthActionCohortLibrary {
                 "    LEFT JOIN (select o.patient_id,o.hiv_status_at_exit from kenyaemr_etl.etl_hei_enrollment o where o.encounter_type = 'MCHCS_HEI_COMPLETION'\n" +
                 "                   and o.visit_date <= date(:endDate)) o on o.patient_id = e.patient_id\n" +
                 "                               left join kenyaemr_etl.etl_patient_program_discontinuation c\n" +
-                "                               on e.patient_id = c.patient_id and c.program_name = 'MCH Child HEI'\n" +
+                "                               on e.patient_id = c.patient_id and c.program_name in ('MCH Child HEI','MCH Child')\n" +
                 "                               left join kenyaemr_etl.etl_hts_test t on t.patient_id = e.patient_id\n" +
                 "WHERE d.hei_no is not null\n" +
                 "  AND DATE_ADD(d.dob, INTERVAL 24 MONTH) BETWEEN date(:startDate) AND date(:endDate)\n" +

--- a/omod/src/main/webapp/pages/dialog/cohortDialog.gsp
+++ b/omod/src/main/webapp/pages/dialog/cohortDialog.gsp
@@ -30,8 +30,15 @@
                 def ds = dataSet;
                 def col = column.name;
 				java.text.SimpleDateFormat dateFormat = new java.text.SimpleDateFormat("dd/MM/yyyy");
-            %>
+
+				def getUniquePatientNumber = { patient ->
+					def upn = patient.identifiers.find { it.identifierType == "Unique Patient Number" }
+					return upn ? upn.identifier : ""
+				}
+
+			%>
 			<% patients.each { patient -> %>
+
 			<tr>
 				<td>
 					<img src="${ ui.resourceLink("kenyaui", "images/glyphs/patient_" + patient.gender.toLowerCase() + ".png") }" class="ke-glyph" />
@@ -40,8 +47,8 @@
 				<td>${ patient.age }</td>
 				<td>${ ageAtReportingResults.getData().get(patient.id) }</td>
 				<td>${ patient.gender.toUpperCase() }</td>
-				<td>${ patient.identifiers[0].identifier }</td>
-			    <td>${ enrollmentDates.get(patient.id) != null? (enrollmentDates.get(patient.id).value != null ?
+			<td><%= getUniquePatientNumber(patient) %></td>
+			<td>${ enrollmentDates.get(patient.id) != null? (enrollmentDates.get(patient.id).value != null ?
 						dateFormat.format(enrollmentDates.get(patient.id).value) : "") : ""  }</td>
                 <td>${ artInitializationDates.get(patient.id) != null ?
 						dateFormat.format(artInitializationDates.get(patient.id).value) : "" }</td>


### PR DESCRIPTION
- Added chore to update existing obs with concept 856 to 163545 created through CWC followup form
- Updated View cohort gsp to poppulate ccc number as unique patient number and if it does not exist, default to blank string. Handles populating UPN column with other identifiers e.g National ID. 
- Updated HEI without final outcome at 24 months query to include MCH Child encounter