### PR TITLE
KHP3-7309/Added a config to toggle between custom/Fhir responses from HIE called fhirFormat

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/metadata/CommonMetadata.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/metadata/CommonMetadata.java
@@ -81,6 +81,7 @@ public class CommonMetadata extends AbstractMetadataBundle {
 	public static final String GP_CLINICAL_ACTION_HEI_ABSOLUTE_THRESHOLD = "kenyaemr.clinical.action.hei.absolute.threshold";
 	public static final String GP_SHA_JWT_AUTH_MODE = "kenyaemr.sha.jwt.auth.mode";
 	public static final String GP_SHA_INTERVENTIONS_PAGE_SIZE = "kenyaemr.sha.interventions.page.size";
+	public static final String GP_SHA_JWT_HEI_RESPONSE_FORMAT = "kenyaemr.sha.jwt.response.fhirFormat";
 
 
 	public static final class _EncounterType {

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -428,4 +428,11 @@
 			Populate Specific Risk Factors/Chronic Illnesses on Final Diagnosis
 		</description>
 </globalProperty>
+<globalProperty>
+		<property>kenyaemr.sha.jwt.response.fhirFormat</property>
+		<defaultValue>false</defaultValue>
+		<description>
+			Defines whether to get HIE responses in FHIR format or custom format
+		</description>
+</globalProperty>
 </module>


### PR DESCRIPTION
… 
<img width="489" height="506" alt="Screenshot from 2025-08-27 18-02-47" src="https://github.com/user-attachments/assets/5fda13fe-7703-45ee-942a-1578ee3de863" />




Purpose:
1. Created a config to toggle usage of HWR search between FHIR and Custon endpoint
                       FHIR:        https://api.safaricom.co.ke/hie/api/v1/hl/facade/fhir/practitioner
			Custom:   https://api.safaricom.co.ke/hie/api/v1/professional
2. This PR adds an object to the custom response of fhirFormat to distinguish
